### PR TITLE
fix: align installer docs and verification counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,11 @@ jobs:
             count=$((count + 1))
           done
           echo "All $count skills have valid frontmatter"
+      - name: Installer smoke test
+        run: bash scripts/test-install.sh
+      - name: Check install docs consistency
+        run: |
+          if rg -n 'Spawn 578 agents|578 agents|282 agent-packs|282개 에이전트팩|95 skills|95개 스킬|95 スキル|95 个技能|Skills \| 95|스킬 \| 95|技能 \| 95' README.md AI-INSTALL.md SETUP.md docs/index.html docs/i18n; then
+            echo "Found stale install counts in first-party docs"
+            exit 1
+          fi

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -112,20 +112,18 @@ jobs:
           AWESOME_CORE_COUNT=$(find codex-agents/awesome-core -name '*.toml' 2>/dev/null | wc -l)
           PACK_COUNT=$(find codex-agents/agent-packs -name '*.toml' 2>/dev/null | wc -l)
           AGENCY_TOML_COUNT=$(find codex-agents/agency -name '*.toml' 2>/dev/null | wc -l)
-          # Subtract core-vs-awesome filename overlap (both install to ~/.codex/agents/)
-          # Overlap: agents in omo/omc/awesome-core that also exist in awesome/
-          OVERLAP=$(comm -12 \
-            <({ find codex-agents/core codex-agents/omo codex-agents/omc codex-agents/awesome-core -name '*.toml' -exec basename {} \; 2>/dev/null; } | sort -u) \
-            <(find codex-agents/awesome -name '*.toml' -exec basename {} \; 2>/dev/null | sort -u) \
-            | wc -l)
-          TOTAL_AGENTS=$((CORE_COUNT + OMO_COUNT + OMC_COUNT + AWESOME_CORE_COUNT + PACK_COUNT + AGENCY_TOML_COUNT + AWESOME_COUNT - OVERLAP))
+          eval "$(bash scripts/compute-install-counts.sh)"
           echo "CORE_COUNT=$CORE_COUNT" >> $GITHUB_ENV
           echo "OMO_COUNT=$OMO_COUNT" >> $GITHUB_ENV
           echo "OMC_COUNT=$OMC_COUNT" >> $GITHUB_ENV
           echo "AWESOME_CORE_COUNT=$AWESOME_CORE_COUNT" >> $GITHUB_ENV
           echo "PACK_COUNT=$PACK_COUNT" >> $GITHUB_ENV
           echo "AGENCY_TOML_COUNT=$AGENCY_TOML_COUNT" >> $GITHUB_ENV
-          echo "TOTAL_AGENTS=$TOTAL_AGENTS" >> $GITHUB_ENV
+          echo "AUTO_LOADED_COUNT=$AUTO_LOADED_COUNT" >> $GITHUB_ENV
+          echo "AGENT_PACK_COUNT=$AGENT_PACK_COUNT" >> $GITHUB_ENV
+          echo "SKILL_COUNT=$SKILL_COUNT" >> $GITHUB_ENV
+          echo "INSTALLED_AGENT_TOTAL=$INSTALLED_AGENT_TOTAL" >> $GITHUB_ENV
+          echo "SOURCE_TOML_COUNT=$SOURCE_TOML_COUNT" >> $GITHUB_ENV
 
       # 6. Update SOURCES.json
       - name: Update SOURCES.json
@@ -166,69 +164,54 @@ jobs:
       # 7. Update documentation counts
       - name: Update documentation counts
         run: |
-          TOTAL_SKILLS=$((ECC_SKILLS + OMX_CDX_SKILLS))
-          # Compute AUTO_LOADED / PACK_LOADED (used by both index.html and AI-INSTALL.md)
-          AWESOME_CORE_CATS=0
-          for d in codex-agents/awesome/01-core-development codex-agents/awesome/03-infrastructure codex-agents/awesome/04-quality-security codex-agents/awesome/09-meta-orchestration; do
-            AWESOME_CORE_CATS=$((AWESOME_CORE_CATS + $(find "$d" -name '*.toml' 2>/dev/null | wc -l)))
-          done
-          AUTO_LOADED=$((CORE_COUNT + OMO_COUNT + OMC_COUNT + AWESOME_CORE_COUNT + AWESOME_CORE_CATS - OVERLAP))
-          PACK_LOADED=$((TOTAL_AGENTS - AUTO_LOADED))
-          for f in README.md docs/i18n/README.ko.md docs/i18n/README.ja.md docs/i18n/README.zh.md docs/i18n/README.de.md docs/i18n/README.fr.md AI-INSTALL.md; do
+          eval "$(bash scripts/compute-install-counts.sh)"
+          for f in README.md docs/i18n/README.ko.md docs/i18n/README.ja.md docs/i18n/README.zh.md docs/i18n/README.de.md docs/i18n/README.fr.md; do
             [ -f "$f" ] || continue
-            # shields.io badges use underscore: "444_agents"
-            sed -i -E "s/[0-9]+_agents/${TOTAL_AGENTS}_agents/g" "$f"
-            sed -i -E "s/[0-9]+_skills/${TOTAL_SKILLS}_skills/g" "$f"
-            # Prose text: "444 agents"
-            sed -i -E "s/[0-9]+ agents/${TOTAL_AGENTS} agents/g" "$f"
-            sed -i -E "s/[0-9]+ skills/${TOTAL_SKILLS} skills/g" "$f"
+            sed -i -E "s/skills-[0-9]+/skills-${SKILL_COUNT}/g" "$f"
+            sed -i -E "s/agents-[0-9]+/agents-${INSTALLED_AGENT_TOTAL}/g" "$f"
+            sed -i -E "s/\\*\\*[0-9]+ installed agent files\\*\\*/**${INSTALLED_AGENT_TOTAL} installed agent files**/g" "$f" || true
           done
 
           # docs/index.html — targeted updates (avoid greedy global replace)
           if [ -f docs/index.html ]; then
-            # Meta tags: "N agents (N auto-loaded + N agent-packs)"
-            sed -i -E 's/[0-9]+ agents \([0-9]+ auto-loaded \+ [0-9]+ agent-packs\)/'"${TOTAL_AGENTS} agents (${AUTO_LOADED} auto-loaded + ${PACK_LOADED} agent-packs)"'/g' docs/index.html
+            sed -i -E 's/[0-9]+ installed agent files \([0-9]+ auto-loaded \+ [0-9]+ agent-packs\)/'"${INSTALLED_AGENT_TOTAL} installed agent files (${AUTO_LOADED_COUNT} auto-loaded + ${AGENT_PACK_COUNT} agent-packs)"'/g' docs/index.html
             # Hero data-count attributes
-            sed -i -E 's/data-count="[0-9]+"(>0<\/em> <span class="lang" data-en="agents")/data-count="'"${TOTAL_AGENTS}"'"\1/' docs/index.html
-            sed -i -E 's/data-count="[0-9]+"(>0<\/em> <span class="lang" data-en="skills")/data-count="'"${TOTAL_SKILLS}"'"\1/' docs/index.html
+            sed -i -E 's/data-count="[0-9]+"(>0<\/em> <span class="lang" data-en="agents")/data-count="'"${INSTALLED_AGENT_TOTAL}"'"\1/' docs/index.html
+            sed -i -E 's/data-count="[0-9]+"(>0<\/em> <span class="lang" data-en="skills")/data-count="'"${SKILL_COUNT}"'"\1/' docs/index.html
             # Comparison table
-            sed -i -E 's/(&#x2705; )[0-9]+(.*Native TOML)/\1'"${TOTAL_AGENTS}"'\2/' docs/index.html
-            sed -i -E 's/(&#x2705; )[0-9]+(.*Skills included)/\1'"${TOTAL_SKILLS}"'\2/' docs/index.html
+            sed -i -E 's/(&#x2705; )[0-9]+(.*Native TOML)/\1'"${INSTALLED_AGENT_TOTAL}"'\2/' docs/index.html
+            sed -i -E 's/(&#x2705; )[0-9]+(.*Skills included)/\1'"${SKILL_COUNT}"'\2/' docs/index.html
             # Badges (shields.io underscore format)
-            sed -i -E "s/[0-9]+_agents/${TOTAL_AGENTS}_agents/g" docs/index.html
-            sed -i -E "s/[0-9]+_skills/${TOTAL_SKILLS}_skills/g" docs/index.html
-            # "All N agents" in principles/catalog (EN + KO)
-            sed -i -E "s/All [0-9]+ agents/All ${TOTAL_AGENTS} agents/g" docs/index.html
-            sed -i -E "s/[0-9]+개 에이전트 모두/${TOTAL_AGENTS}개 에이전트 모두/g" docs/index.html
-            # "N agents organized" in catalog header (EN + KO)
-            sed -i -E "s/[0-9]+ agents organized/${TOTAL_AGENTS} agents organized/g" docs/index.html
-            sed -i -E "s/[0-9]+개 에이전트를 자동/${TOTAL_AGENTS}개 에이전트를 자동/g" docs/index.html
-            # "N native TOML agents" in hero tagline (EN + KO)
-            sed -i -E "s/[0-9]+ native TOML agents/${TOTAL_AGENTS} native TOML agents/g" docs/index.html
-            sed -i -E "s/위한 [0-9]+개 네이티브/위한 ${TOTAL_AGENTS}개 네이티브/g" docs/index.html
-            # "Done. N agents ready." in terminal demo (EN + KO)
-            sed -i -E "s/Done\. [0-9]+ agents ready/Done. ${TOTAL_AGENTS} agents ready/g" docs/index.html
-            sed -i -E "s/완료\. [0-9]+개 에이전트 준비됨/완료. ${TOTAL_AGENTS}개 에이전트 준비됨/g" docs/index.html
-            # "N agents, N skills" in install section (EN + KO)
-            sed -i -E "s/— [0-9]+ agents, [0-9]+ skills/— ${TOTAL_AGENTS} agents, ${TOTAL_SKILLS} skills/g" docs/index.html
-            sed -i -E "s/— [0-9]+개 에이전트, [0-9]+개 스킬/— ${TOTAL_AGENTS}개 에이전트, ${TOTAL_SKILLS}개 스킬/g" docs/index.html
-            # FAQ "aggregates N agents"
-            sed -i -E "s/aggregates [0-9]+ agents/aggregates ${TOTAL_AGENTS} agents/g" docs/index.html
-            sed -i -E "s/소스에서 [0-9]+개 에이전트를/소스에서 ${TOTAL_AGENTS}개 에이전트를/g" docs/index.html
+            sed -i -E "s/[0-9]+_agents/${INSTALLED_AGENT_TOTAL}_agents/g" docs/index.html
+            sed -i -E "s/[0-9]+_skills/${SKILL_COUNT}_skills/g" docs/index.html
+            sed -i -E "s/[0-9]+ installed native TOML agent files/${INSTALLED_AGENT_TOTAL} installed native TOML agent files/g" docs/index.html
+            sed -i -E "s/[0-9]+개 설치 네이티브 TOML 에이전트 파일/${INSTALLED_AGENT_TOTAL}개 설치 네이티브 TOML 에이전트 파일/g" docs/index.html
+            sed -i -E "s/[0-9]+ agent-packs →/$(printf '%s' "${AGENT_PACK_COUNT}") agent-packs →/g" docs/index.html
+            sed -i -E "s/[0-9]+개 에이전트팩 →/${AGENT_PACK_COUNT}개 에이전트팩 →/g" docs/index.html
+            sed -i -E 's/(Agent Packs".*<span class="cnt">)[0-9]+(<\/span>)/\1'"${AGENT_PACK_COUNT}"'\2/' docs/index.html
+            sed -i -E "s/All [0-9]+ installed agent files/All ${INSTALLED_AGENT_TOTAL} installed agent files/g" docs/index.html
+            sed -i -E "s/설치되는 [0-9]+개 에이전트 파일 모두/설치되는 ${INSTALLED_AGENT_TOTAL}개 에이전트 파일 모두/g" docs/index.html
+            sed -i -E "s/[0-9]+ installed agent files organized/${INSTALLED_AGENT_TOTAL} installed agent files organized/g" docs/index.html
+            sed -i -E "s/[0-9]+개 설치 에이전트 파일을/${INSTALLED_AGENT_TOTAL}개 설치 에이전트 파일을/g" docs/index.html
+            sed -i -E "s/Done\. [0-9]+ installed agent files ready/Done. ${INSTALLED_AGENT_TOTAL} installed agent files ready/g" docs/index.html
+            sed -i -E "s/완료\. [0-9]+개 설치 에이전트 파일 준비됨/완료. ${INSTALLED_AGENT_TOTAL}개 설치 에이전트 파일 준비됨/g" docs/index.html
+            sed -i -E "s/aggregates 4 curated upstream sources into [0-9]+ installed agent files and [0-9]+ skills/aggregates 4 curated upstream sources into ${INSTALLED_AGENT_TOTAL} installed agent files and ${SKILL_COUNT} skills/g" docs/index.html
             # Pipeline diagram "N + N + N"
-            sed -i -E "s/[0-9]+ \+ [0-9]+ \+ [0-9]+/${AUTO_LOADED} + ${PACK_LOADED} + ${TOTAL_SKILLS}/" docs/index.html
-            # "All N packs" in catalog (EN + KO)
-            sed -i -E "s/All [0-9]+ packs/All ${PACK_LOADED} packs/g" docs/index.html
-            sed -i -E "s/전체 [0-9]+개 팩이/전체 ${PACK_LOADED}개 팩이/g" docs/index.html
+            sed -i -E "s/[0-9]+ \+ [0-9]+ \+ [0-9]+/${AUTO_LOADED_COUNT} + ${AGENT_PACK_COUNT} + ${SKILL_COUNT}/" docs/index.html
+            sed -i -E "s/All [0-9]+ installed pack files/All ${AGENT_PACK_COUNT} installed pack files/g" docs/index.html
+            sed -i -E "s/전체 [0-9]+개 팩 파일이/전체 ${AGENT_PACK_COUNT}개 팩 파일이/g" docs/index.html
           fi
 
           # AI-INSTALL.md — update detail counts
           if [ -f AI-INSTALL.md ]; then
-            sed -i -E "s/~[0-9]+ core agents/~${AUTO_LOADED} core agents/" AI-INSTALL.md
-            sed -i -E "s/~[0-9]+ domain agent-packs/~${PACK_LOADED} domain agent-packs/" AI-INSTALL.md
-            sed -i -E "s/Core agents: [0-9]+\+/Core agents: ${AUTO_LOADED}+/" AI-INSTALL.md
-            sed -i -E "s/Agent packs: [0-9]+\+/Agent packs: ${PACK_LOADED}+/" AI-INSTALL.md
-            sed -i -E "s/Skills: [0-9]+\+/Skills: ${TOTAL_SKILLS}+/" AI-INSTALL.md
+            sed -i -E "s/installs [0-9]+ agent files \(.*\), [0-9]+ skills/installs ${INSTALLED_AGENT_TOTAL} agent files (${AUTO_LOADED_COUNT} auto-loaded + ${AGENT_PACK_COUNT} agent-packs), ${SKILL_COUNT} skills/" AI-INSTALL.md
+            sed -i -E "s/repository currently contains [0-9]+ TOML definitions/repository currently contains ${SOURCE_TOML_COUNT} TOML definitions/" AI-INSTALL.md
+            sed -i -E "s/- [0-9]+ auto-loaded agents/- ${AUTO_LOADED_COUNT} auto-loaded agents/" AI-INSTALL.md
+            sed -i -E "s/- [0-9]+ domain agent-packs/- ${AGENT_PACK_COUNT} domain agent-packs/" AI-INSTALL.md
+            sed -i -E "s/- [0-9]+ skills/- ${SKILL_COUNT} skills/" AI-INSTALL.md
+            sed -i -E "s/Core agents: [0-9]+/Core agents: ${AUTO_LOADED_COUNT}/" AI-INSTALL.md
+            sed -i -E "s/Agent packs: [0-9]+/Agent packs: ${AGENT_PACK_COUNT}/" AI-INSTALL.md
+            sed -i -E "s/Skills: [0-9]+/Skills: ${SKILL_COUNT}/" AI-INSTALL.md
           fi
 
       # 8. Create PR

--- a/AI-INSTALL.md
+++ b/AI-INSTALL.md
@@ -1,7 +1,8 @@
 # my-codex AI Installation Guide
 
 You are an AI agent setting up a Codex CLI multi-agent orchestration environment.
-The bundle includes 578 agents, 125 skills, and 3 MCP servers.
+The bundle installs 444 agent files (80 auto-loaded + 364 agent-packs), 125 skills, and 3 MCP servers.
+The repository currently contains 589 TOML definitions from overlapping upstream sources; install-time deduplication reduces that to the final installed footprint.
 Only 2-3 steps are needed.
 
 ---
@@ -15,12 +16,17 @@ rm -rf /tmp/my-codex
 ```
 
 This installs:
-- ~91 core agents in `~/.codex/agents/` (always loaded by Codex CLI via `spawn_agent`)
-- ~487 domain agent-packs in `~/.codex/agent-packs/` (on-demand via symlink)
+- 80 auto-loaded agents in `~/.codex/agents/` (always loaded by Codex CLI via `spawn_agent`)
+- 364 domain agent-packs in `~/.codex/agent-packs/` (on-demand via symlink)
 - 125 skills in `~/.codex/skills/` (from Everything Claude Code)
 - Global `AGENTS.md` instructions
 - `config.toml` with `multi_agent = true`
 - 3 MCP servers (Context7 — real-time library docs, Exa — web search, grep_app — GitHub code search)
+
+Why the numbers are lower than raw source totals:
+- Several upstream sources ship the same destination filename.
+- `install.sh` merges those sources into `~/.codex/agents/` and category folders under `~/.codex/agent-packs/`.
+- When filenames overlap, later copies replace earlier ones. The final installed counts above are the correct verification target.
 
 ## Step 1b: Manual install (if install.sh unavailable)
 
@@ -58,7 +64,7 @@ for d in /tmp/my-codex/codex-agents/awesome/*/; do
 done
 
 # Skills
-cp -r /tmp/my-codex/skills/ecc/* ~/.codex/skills/
+cp -R /tmp/my-codex/skills/ecc/. ~/.codex/skills/
 cp /tmp/my-codex/templates/codex-AGENTS.md ~/.codex/AGENTS.md
 
 # Create config.toml
@@ -71,10 +77,10 @@ child_agents_md = true
 max_threads = 8
 TOML
 
-# MCP servers
-codex mcp add context7  --url https://mcp.context7.com/mcp 2>/dev/null || true
-codex mcp add exa       --url "https://mcp.exa.ai/mcp?tools=web_search_exa" 2>/dev/null || true
-codex mcp add grep_app  --url https://mcp.grep.app 2>/dev/null || true
+# MCP servers (skip names that already exist to avoid re-triggering auth flows)
+codex mcp list 2>/dev/null | grep -qE '^context7[[:space:]]' || codex mcp add context7 --url https://mcp.context7.com/mcp 2>/dev/null || true
+codex mcp list 2>/dev/null | grep -qE '^exa[[:space:]]' || codex mcp add exa --url "https://mcp.exa.ai/mcp?tools=web_search_exa" 2>/dev/null || true
+codex mcp list 2>/dev/null | grep -qE '^grep_app[[:space:]]' || codex mcp add grep_app --url https://mcp.grep.app 2>/dev/null || true
 
 rm -rf /tmp/my-codex
 ```
@@ -107,9 +113,9 @@ echo "config.toml:   $(grep -q 'multi_agent' ~/.codex/config.toml 2>/dev/null &&
 ```
 
 Expected:
-- Core agents: 91+
-- Agent packs: 487+
-- Skills: 125+
+- Core agents: 80
+- Agent packs: 364
+- Skills: 125
 - AGENTS.md: OK
 - config.toml: OK
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Agents](https://img.shields.io/badge/agents-444-blue)
-![Skills](https://img.shields.io/badge/skills-95-purple)
+![Skills](https://img.shields.io/badge/skills-125-purple)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
 ![Auto Sync](https://img.shields.io/badge/upstream_sync-weekly-brightgreen)
 
 All-in-one multi-agent orchestration for OpenAI Codex CLI — install once, get everything.
 
-Bundles **578 agents** (80 auto-loaded + 498 agent-packs) and **125 skills** from 4 upstream sources into native TOML format. Codex CLI auto-discovers agents via `spawn_agent` and routes tasks to the optimal specialist. GitHub Actions CI syncs upstream changes weekly.
+Bundles **444 installed agent files** (80 auto-loaded + 364 agent-packs) and **125 skills** from 4 upstream sources into native TOML format. The repo currently contains 589 TOML source definitions; install-time deduplication resolves overlapping destination filenames into the final installed footprint. Codex CLI auto-discovers agents via `spawn_agent` and routes tasks to the optimal specialist. GitHub Actions CI syncs upstream changes weekly.
 
 Based on the official [Codex Subagents](https://developers.openai.com/codex/subagents) specification.
 
@@ -32,7 +32,7 @@ Based on the official [Codex Subagents](https://developers.openai.com/codex/suba
 |-----------|-------------|
 | **Native TOML** | All agents in Codex CLI's native `.toml` format — no runtime conversion, no compatibility issues |
 | **Multi-Source Curation** | 4 upstream sources aggregated, deduplicated, and quality-checked into a single collection |
-| **Zero Configuration** | Install once, get 578 agents. `config.toml` auto-configured with `multi_agent = true` |
+| **Zero Configuration** | Install once, get 444 ready-to-use agent files. `config.toml` auto-configured with `multi_agent = true` |
 
 ## Quick Start
 
@@ -71,7 +71,7 @@ Read the full output and execute each step in order. Use `curl`, not `WebFetch`.
 - **o4-mini (low)**: Quick lookups, exploration — mapped from Claude Haiku equivalents
 
 ### All-in-One Bundle
-- Install provides **578 agents and 125 skills** instantly
+- Install provides **444 installed agent files and 125 skills** instantly
 - Bundles 4 upstream sources (agency-agents, everything-claude-code, oh-my-codex, awesome-codex-subagents)
 - Weekly CI auto-sync keeps bundled content up-to-date with upstream
 - MD-to-TOML conversion handled automatically for non-native sources
@@ -80,7 +80,7 @@ Read the full output and execute each step in order. Use `curl`, not `WebFetch`.
 
 ## Core Agents
 
-37 core agents providing orchestration infrastructure are installed to `~/.codex/agents/`. These are the foundation agents that orchestrate, plan, review, and verify work. Domain specialists are in agent-packs. Awesome agents (136) are also installed to `~/.codex/agents/` for additional coverage (578 agents shared between core and awesome, yielding 80 unique auto-loaded agents).
+37 core agents providing orchestration infrastructure are installed to `~/.codex/agents/`. These are the foundation agents that orchestrate, plan, review, and verify work. Domain specialists are in agent-packs. Awesome agents add additional coverage, but overlapping filenames collapse the final auto-loaded set to 80 installed files.
 
 ### Orchestrators (5)
 boss, sisyphus, atlas, hephaestus, prometheus
@@ -107,7 +107,7 @@ test-engineer, qa-tester, multimodal-looker
 
 ## Agent Packs (Domain Specialists)
 
-282 domain agents across 21 categories installed to `~/.codex/agent-packs/` — **not** loaded by default. Activate a pack by symlinking:
+364 installed pack files across 21 categories are written to `~/.codex/agent-packs/` — **not** loaded by default. Those files come from `agent-packs/`, `agency/`, and non-core awesome categories after install-time deduplication. Activate a pack by symlinking:
 
 ```bash
 # Activate a single pack
@@ -147,11 +147,13 @@ rm ~/.codex/agents/<agent-name>.toml
 
 | Category | Count | Source | Location |
 |------|------|------|------|
-| Auto-loaded Agents | 80 (37 core + 54 awesome − 11 shared) | Orchestration infrastructure + awesome core | `~/.codex/agents/` |
-| Agent Packs | 498 (282 packs + 134 agency + 82 awesome) | 21 domain categories + agency specialists + awesome domain | `~/.codex/agent-packs/` |
-| Skills | 95 | ECC | `~/.codex/skills/` |
+| Auto-loaded Agents | 80 installed files | `core/`, `omo/`, `omc/`, `awesome-core/`, awesome core categories | `~/.codex/agents/` |
+| Agent Packs | 364 installed files | `agent-packs/`, `agency/`, awesome non-core categories | `~/.codex/agent-packs/` |
+| Skills | 125 | ECC | `~/.codex/skills/` |
 | config.toml | 1 | my-codex | `~/.codex/config.toml` |
 | AGENTS.md | 1 | my-codex | `~/.codex/AGENTS.md` |
+
+The repository source inventory is larger than the install footprint because multiple upstreams ship the same destination filename. `install.sh` verifies the installed counts above, not the raw source totals.
 
 <details>
 <summary>Awesome Core Agents (52) — From awesome-codex-subagents</summary>
@@ -173,7 +175,7 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 </details>
 
 <details>
-<summary>Skills (95) — From Everything Claude Code</summary>
+<summary>Skills (125) — From Everything Claude Code</summary>
 
 Key skills include:
 
@@ -222,11 +224,11 @@ Key skills include:
 │_agent│ │N       │ │input   │ │toml    │
 └──────┘ └────────┘ └────────┘ └────────┘
 ┌─────────────────────────────────────────────────────────┐
-│  Agent Layer (444 unique agents in native TOML)          │
-│    ├── Auto-loaded (80): 37 core + 54 awesome − 11 shared│
-│    └── Agent Packs (498): 282 packs + 134 agency + 82 awesome│
+│  Agent Layer (444 installed TOML files)                  │
+│    ├── Auto-loaded (80): final installed footprint       │
+│    └── Agent Packs (364): final installed footprint      │
 ├─────────────────────────────────────────────────────────┤
-│  Skills Layer (95 from ECC)                             │
+│  Skills Layer (125 from ECC)                            │
 │    ├── tdd-workflow, security-review, autopilot         │
 │    └── pdf, docx, pptx, xlsx, team                     │
 └─────────────────────────────────────────────────────────┘
@@ -301,7 +303,7 @@ Codex → spawn_agent("security-reviewer")
 ### Parallel Spawn
 
 ```
-> Spawn 578 agents: refactor auth, add tests, review security
+> Run a multi-agent pass: refactor auth, add tests, review security
 
 Codex → spawn_agent("executor") × refactoring
       → spawn_agent("test-engineer") × test writing

--- a/SETUP.md
+++ b/SETUP.md
@@ -48,8 +48,8 @@ What gets installed:
 | Destination | Contents |
 |---|---|
 | `~/.codex/agents/` | 80 unique agents (37 core + 136 awesome, deduplicated) |
-| `~/.codex/agent-packs/` | 282 on-demand pack agents |
-| `~/.codex/skills/` | 95 skills |
+| `~/.codex/agent-packs/` | 364 on-demand pack files after upstream overlap is deduplicated during install |
+| `~/.codex/skills/` | 125 skills |
 | `~/.codex/AGENTS.md` | Agent catalog and routing instructions |
 | `~/.codex/config.toml` | `multi_agent = true` + model defaults |
 | `~/.codex/.mcp.json` | 3 MCP servers: context7, exa, grep_app |
@@ -69,11 +69,13 @@ echo "config.toml:  $(grep -q multi_agent ~/.codex/config.toml && echo OK || ech
 Expected output:
 ```
 Core agents:  80
-Agent packs:  282
-Skills:       95
+Agent packs:  364
+Skills:       125
 AGENTS.md:    OK
 config.toml:  OK
 ```
+
+Note: the repository contains more raw TOML files than the final installed counts. `install.sh` verifies the installed footprint above, not the pre-deduped source totals.
 
 ---
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -14,13 +14,13 @@
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Agents](https://img.shields.io/badge/agents-444-blue)
-![Skills](https://img.shields.io/badge/skills-95-purple)
+![Skills](https://img.shields.io/badge/skills-125-purple)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
 ![Auto Sync](https://img.shields.io/badge/upstream_sync-weekly-brightgreen)
 
 All-in-One Multi-Agent-Orchestrierung für OpenAI Codex CLI — einmalige Installation, alles inklusive.
 
-Bündelt **444 Agenten** (80 automatisch geladen + 364 Agent-Pakete) und **95 Skills** aus 4 vorgelagerten Quellen im nativen TOML-Format. Codex CLI entdeckt Agenten automatisch über `spawn_agent` und leitet Aufgaben zum optimalen Spezialisten weiter. GitHub Actions CI synchronisiert vorgelagerte Änderungen wöchentlich.
+Bündelt **444 installierte Agent-Dateien** (80 automatisch geladen + 364 Agent-Pakete) und **125 Skills** aus 4 vorgelagerten Quellen im nativen TOML-Format. Codex CLI entdeckt Agenten automatisch über `spawn_agent` und leitet Aufgaben zum optimalen Spezialisten weiter. GitHub Actions CI synchronisiert vorgelagerte Änderungen wöchentlich.
 
 Basierend auf der offiziellen [Codex Subagents](https://developers.openai.com/codex/subagents) Spezifikation.
 
@@ -71,7 +71,7 @@ Lese die vollständige Ausgabe und führe jeden Schritt in der Reihenfolge aus. 
 - **o4-mini (niedrig)**: Schnelle Lookups, Exploration — aus Claude Haiku Äquivalenten zugeordnet
 
 ### All-in-One Bundle
-- Installation bietet **444 Agenten und 95 Skills** sofort
+- Installation bietet **444 installierte Agent-Dateien und 125 Skills** sofort
 - Bündelt 4 vorgelagerte Quellen (agency-agents, everything-claude-code, oh-my-codex, awesome-codex-subagents)
 - Wöchentliche CI Auto-Sync hält gebündelte Inhalte mit vorgelagerten Quellen aktuell
 - MD-zu-TOML-Konvertierung wird automatisch für Nicht-Native-Quellen durchgeführt
@@ -107,7 +107,7 @@ test-engineer, qa-tester, multimodal-looker
 
 ## Agent-Pakete (Domänen-Spezialisten)
 
-282 Domänen-Agenten über 21 Kategorien installiert in `~/.codex/agent-packs/` — werden **nicht** standardmäßig geladen. Aktiviere ein Paket durch Symlink:
+364 installierte Paketdateien über 21 Kategorien werden in `~/.codex/agent-packs/` geschrieben — sie werden **nicht** standardmäßig geladen. Aktiviere ein Paket per Symlink:
 
 ```bash
 # Aktiviere ein einzelnes Paket
@@ -148,8 +148,8 @@ rm ~/.codex/agents/<agent-name>.toml
 | Kategorie | Anzahl | Quelle | Ort |
 |------|--------|--------|-----|
 | Automatisch geladene Agenten | 80 (37 Core + 54 Awesome − 11 gemeinsam) | Orchestrierungs-Infrastruktur + Awesome Core | `~/.codex/agents/` |
-| Agent-Pakete | 364 (282 Pakete + 82 Awesome) | 21 Domänen-Kategorien + Awesome Domain | `~/.codex/agent-packs/` |
-| Skills | 95 | ECC | `~/.codex/skills/` |
+| Agent-Pakete | 364 installierte Dateien | `agent-packs/`, `agency/`, Awesome-Nicht-Core-Kategorien | `~/.codex/agent-packs/` |
+| Skills | 125 | ECC | `~/.codex/skills/` |
 | config.toml | 1 | my-codex | `~/.codex/config.toml` |
 | AGENTS.md | 1 | my-codex | `~/.codex/AGENTS.md` |
 
@@ -173,7 +173,7 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 </details>
 
 <details>
-<summary>Skills (95) — Aus Everything Claude Code</summary>
+<summary>Skills (125) — Aus Everything Claude Code</summary>
 
 Wichtige Skills beinhalten:
 
@@ -223,10 +223,10 @@ Wichtige Skills beinhalten:
 └──────┘ └────────┘ └────────┘ └────────┘
 ┌─────────────────────────────────────────────────────────┐
 │  Agent Layer (444 unique agents in native TOML)          │
-│    ├── Auto-loaded (80): 37 core + 54 awesome − 11 shared│
-│    └── Agent Packs (364): 282 packs + 82 awesome         │
+│    ├── Auto-loaded (80): final installed footprint       │
+│    └── Agent Packs (364): final installed footprint      │
 ├─────────────────────────────────────────────────────────┤
-│  Skills Layer (95 from ECC)                             │
+│  Skills Layer (125 from ECC)                            │
 │    ├── tdd-workflow, security-review, autopilot         │
 │    └── pdf, docx, pptx, xlsx, team                     │
 └─────────────────────────────────────────────────────────┘
@@ -301,7 +301,7 @@ Codex → spawn_agent("security-reviewer")
 ### Paralleles Spawning
 
 ```
-> Spawn 578 agents: refactor auth, add tests, review security
+> Run a multi-agent pass: refactor auth, add tests, review security
 
 Codex → spawn_agent("executor") × refactoring
       → spawn_agent("test-engineer") × test writing
@@ -347,7 +347,7 @@ Eine Bibliothek mit 156 Business-Spezialisten-Agent-Personas. Bietet Spezialiste
 
 ### 2. [Everything Claude Code (ECC)](https://github.com/affaan-m/everything-claude-code)
 
-Ein Entwicklungs-Framework, ursprünglich für Claude Code entwickelt, das 95 Skills bereitstellt. 13 Claude Code-spezifische Skills wurden entfernt; die verbleibenden Skills enthalten generische Kodierungs-Anleitungen, die über jeden LLM-Agenten verwendbar sind. Das rules/ Verzeichnis ist im Repo als Referenzmaterial enthalten, wird aber von Codex CLI nicht gelesen.
+Ein Entwicklungs-Framework, ursprünglich für Claude Code entwickelt, das 125 Skills bereitstellt. 13 Claude Code-spezifische Skills wurden entfernt; die verbleibenden Skills enthalten generische Kodierungs-Anleitungen, die über jeden LLM-Agenten verwendbar sind. Das rules/ Verzeichnis ist im Repo als Referenzmaterial enthalten, wird aber von Codex CLI nicht gelesen.
 
 ### 3. [Awesome Codex Subagents](https://github.com/VoltAgent/awesome-codex-subagents)
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -14,13 +14,13 @@
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Agents](https://img.shields.io/badge/agents-444-blue)
-![Skills](https://img.shields.io/badge/skills-95-purple)
+![Skills](https://img.shields.io/badge/skills-125-purple)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
 ![Auto Sync](https://img.shields.io/badge/upstream_sync-weekly-brightgreen)
 
 Orchestration multi-agents tout-en-un pour OpenAI Codex CLI — une seule installation, tout inclus.
 
-Regroupe **578 agents** (80 chargés automatiquement + 364 packs d'agents) et **125 skills** issus de 4 sources amont au format TOML natif. Codex CLI découvre les agents automatiquement via `spawn_agent` et route les tâches vers le spécialiste optimal. La CI GitHub Actions synchronise les modifications amont chaque semaine.
+Regroupe **444 fichiers d'agents installés** (80 chargés automatiquement + 364 packs d'agents) et **125 skills** issus de 4 sources amont au format TOML natif. Codex CLI découvre les agents automatiquement via `spawn_agent` et route les tâches vers le spécialiste optimal. La CI GitHub Actions synchronise les modifications amont chaque semaine.
 
 Basé sur la spécification officielle [Codex Subagents](https://developers.openai.com/codex/subagents).
 
@@ -32,7 +32,7 @@ Basé sur la spécification officielle [Codex Subagents](https://developers.open
 |----------|-------------|
 | **TOML natif** | Tous les agents au format `.toml` natif de Codex CLI — aucune conversion à l'exécution, aucun problème de compatibilité |
 | **Curation multi-sources** | 4 sources amont agrégées, dédupliquées et contrôlées qualité en une seule collection |
-| **Zéro configuration** | Une installation, 578 agents. `config.toml` est automatiquement configuré avec `multi_agent = true` |
+| **Zéro configuration** | Une installation, 444 fichiers d'agents prêts à l'emploi. `config.toml` est automatiquement configuré avec `multi_agent = true` |
 
 ## Démarrage rapide
 
@@ -71,7 +71,7 @@ Lisez la sortie complète et exécutez chaque étape dans l'ordre. Utilisez `cur
 - **o4-mini (faible)** : Recherches rapides, exploration — mappé depuis les équivalents Claude Haiku
 
 ### Bundle tout-en-un
-- L'installation fournit **578 agents et 125 skills** immédiatement
+- L'installation fournit **444 fichiers d'agents installés et 125 skills** immédiatement
 - Regroupe 4 sources amont (agency-agents, everything-claude-code, oh-my-codex, awesome-codex-subagents)
 - La synchronisation automatique CI hebdomadaire maintient le contenu groupé à jour avec les sources amont
 - La conversion MD-vers-TOML est effectuée automatiquement pour les sources non natives
@@ -80,7 +80,7 @@ Lisez la sortie complète et exécutez chaque étape dans l'ordre. Utilisez `cur
 
 ## Agents principaux
 
-578 agents principaux pour l'infrastructure d'orchestration sont installés dans `~/.codex/agents/`. Ce sont les agents fondamentaux qui orchestrent, planifient, analysent et vérifient le travail. Les spécialistes de domaine se trouvent dans les packs d'agents. Les agents Awesome (136) sont également installés dans `~/.codex/agents/` pour une couverture supplémentaire (578 agents partagés entre Core et Awesome, ce qui donne 578 agents chargés automatiquement uniques).
+37 agents principaux pour l'infrastructure d'orchestration sont installés dans `~/.codex/agents/`. Ce sont les agents fondamentaux qui orchestrent, planifient, analysent et vérifient le travail. Les spécialistes de domaine se trouvent dans les packs d'agents. Les agents Awesome étendent la couverture, mais les collisions de noms de fichiers ramènent l'ensemble auto-chargé final à 80 fichiers installés.
 
 ### Orchestrateurs (5)
 boss, sisyphus, atlas, hephaestus, prometheus
@@ -107,7 +107,7 @@ test-engineer, qa-tester, multimodal-looker
 
 ## Packs d'agents (spécialistes de domaine)
 
-578 agents de domaine répartis en 21 catégories, installés dans `~/.codex/agent-packs/` — **non** chargés par défaut. Activez un pack via un lien symbolique :
+364 fichiers de packs d'agents répartis en 21 catégories sont installés dans `~/.codex/agent-packs/` — **non** chargés par défaut. Activez un pack via un lien symbolique :
 
 ```bash
 # Activer un pack individuel
@@ -148,8 +148,8 @@ rm ~/.codex/agents/<agent-name>.toml
 | Catégorie | Nombre | Source | Emplacement |
 |-----------|--------|--------|-------------|
 | Agents chargés automatiquement | 80 (37 Core + 54 Awesome − 11 partagés) | Infrastructure d'orchestration + Awesome Core | `~/.codex/agents/` |
-| Packs d'agents | 364 (282 packs + 82 Awesome) | 21 catégories de domaine + Awesome Domain | `~/.codex/agent-packs/` |
-| Skills | 95 | ECC | `~/.codex/skills/` |
+| Packs d'agents | 364 fichiers installés | `agent-packs/`, `agency/`, catégories Awesome non core | `~/.codex/agent-packs/` |
+| Skills | 125 | ECC | `~/.codex/skills/` |
 | config.toml | 1 | my-codex | `~/.codex/config.toml` |
 | AGENTS.md | 1 | my-codex | `~/.codex/AGENTS.md` |
 
@@ -173,7 +173,7 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 </details>
 
 <details>
-<summary>Skills (95) — Issus de Everything Claude Code</summary>
+<summary>Skills (125) — Issus de Everything Claude Code</summary>
 
 Skills importants :
 
@@ -223,10 +223,10 @@ Skills importants :
 └──────┘ └────────┘ └────────┘ └────────┘
 ┌─────────────────────────────────────────────────────────┐
 │  Agent Layer (444 unique agents in native TOML)          │
-│    ├── Auto-loaded (80): 37 core + 54 awesome − 11 shared│
-│    └── Agent Packs (364): 282 packs + 82 awesome         │
+│    ├── Auto-loaded (80): empreinte installée finale      │
+│    └── Agent Packs (364): empreinte installée finale     │
 ├─────────────────────────────────────────────────────────┤
-│  Skills Layer (95 from ECC)                             │
+│  Skills Layer (125 from ECC)                            │
 │    ├── tdd-workflow, security-review, autopilot         │
 │    └── pdf, docx, pptx, xlsx, team                     │
 └─────────────────────────────────────────────────────────┘
@@ -301,7 +301,7 @@ Codex → spawn_agent("security-reviewer")
 ### Lancement en parallèle
 
 ```
-> Spawn 578 agents: refactor auth, add tests, review security
+> Run a multi-agent pass: refactor auth, add tests, review security
 
 Codex → spawn_agent("executor") × refactoring
       → spawn_agent("test-engineer") × test writing
@@ -347,11 +347,11 @@ Une bibliothèque de 156 personas d'agents spécialistes métier. Offre des pers
 
 ### 2. [Everything Claude Code (ECC)](https://github.com/affaan-m/everything-claude-code)
 
-Un framework de développement conçu à l'origine pour Claude Code, fournissant 125 skills. 125 skills spécifiques à Claude Code ont été supprimés ; les skills restants contiennent des directives de codage génériques utilisables avec n'importe quel agent LLM. Le répertoire rules/ est inclus dans le dépôt comme matériel de référence, mais n'est pas lu par Codex CLI.
+Un framework de développement conçu à l'origine pour Claude Code, fournissant 125 skills. 13 skills spécifiques à Claude Code ont été supprimés ; les skills restants contiennent des directives de codage génériques utilisables avec n'importe quel agent LLM. Le répertoire rules/ est inclus dans le dépôt comme matériel de référence, mais n'est pas lu par Codex CLI.
 
 ### 3. [Awesome Codex Subagents](https://github.com/VoltAgent/awesome-codex-subagents)
 
-578 agents prêts pour la production au format TOML natif. Déjà compatibles Codex — aucune conversion requise. Organisés en 10 catégories, du développement principal à la méta-orchestration.
+80 fichiers d'agents auto-chargés prêts pour la production au format TOML natif. Déjà compatibles Codex — aucune conversion requise. Organisés en 10 catégories, du développement principal à la méta-orchestration.
 
 ### 4. [Oh My Codex (OMX)](https://github.com/Yeachan-Heo/oh-my-codex)
 
@@ -359,7 +359,7 @@ Framework d'orchestration multi-agents Codex CLI de Yeachan Heo. Un runtime Rust
 
 ### 5. [Oh My OpenAgent (omo)](https://github.com/code-yeongyu/oh-my-openagent)
 
-Un harnais d'agents multi-plateforme de code-yeongyu. Les 578 agents d'orchestration de ce dépôt (atlas, hephaestus, metis, momus, oracle, prometheus, sisyphus, librarian, multimodal-looker) sont adaptés des agents omo, convertis au format TOML natif Codex.
+Un harnais d'agents multi-plateforme de code-yeongyu. Les agents d'orchestration de ce dépôt (atlas, hephaestus, metis, momus, oracle, prometheus, sisyphus, librarian, multimodal-looker) sont adaptés des agents omo, convertis au format TOML natif Codex.
 
 ### 6. [OpenAI Official Skills](https://github.com/openai/skills)
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -14,13 +14,13 @@
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Agents](https://img.shields.io/badge/agents-444-blue)
-![Skills](https://img.shields.io/badge/skills-95-purple)
+![Skills](https://img.shields.io/badge/skills-125-purple)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
 ![Auto Sync](https://img.shields.io/badge/upstream_sync-weekly-brightgreen)
 
 OpenAI Codex CLI 向けオールインワン マルチエージェント オーケストレーション — 一度インストールするだけで、すべてが手に入ります。
 
-**444 エージェント** (80 自動読み込み + 364 エージェントパック) と 4 つのアップストリームソースから **95 スキル** をネイティブ TOML 形式にバンドルします。Codex CLI は `spawn_agent` 経由でエージェントを自動検出し、タスクを最適なスペシャリストにルーティングします。GitHub Actions CI は週単位でアップストリーム変更を同期します。
+**444 インストール済みエージェントファイル** (80 自動読み込み + 364 エージェントパック) と 4 つのアップストリームソースから **125 スキル** をネイティブ TOML 形式にバンドルします。Codex CLI は `spawn_agent` 経由でエージェントを自動検出し、タスクを最適なスペシャリストにルーティングします。GitHub Actions CI は週単位でアップストリーム変更を同期します。
 
 公式 [Codex Subagents](https://developers.openai.com/codex/subagents) 仕様に基づいています。
 
@@ -71,7 +71,7 @@ curl -s https://raw.githubusercontent.com/sehoon787/my-codex/main/AI-INSTALL.md
 - **o4-mini (低推論)**: 高速ルックアップ、探索 — Claude Haiku 相当からマッピング
 
 ### オールインワン バンドル
-- インストールは **444 エージェントと 95 スキル** を即座に提供
+- インストールは **444 インストール済みエージェントファイルと 125 スキル** を即座に提供
 - 4 つのアップストリームソース (agency-agents、everything-claude-code、oh-my-codex、awesome-codex-subagents) をバンドル
 - 週単位の CI 自動同期がバンドルコンテンツをアップストリーム化
 - ネイティブ以外のソース向け MD-to-TOML 変換は自動処理
@@ -107,7 +107,7 @@ test-engineer, qa-tester, multimodal-looker
 
 ## エージェントパック (ドメイン スペシャリスト)
 
-282 個のドメイン エージェント (21 カテゴリ) が `~/.codex/agent-packs/` にインストールされます — デフォルトでは読み込まれません。シンボリックリンク経由でパックを有効化：
+364 個のインストール済みパックファイル (21 カテゴリ) が `~/.codex/agent-packs/` に配置されます — デフォルトでは読み込まれません。シンボリックリンク経由でパックを有効化：
 
 ```bash
 # 単一パックを有効化
@@ -148,8 +148,8 @@ rm ~/.codex/agents/<agent-name>.toml
 | カテゴリ | 数 | ソース | 場所 |
 |------|------|------|------|
 | 自動読み込みエージェント | 80 (37 コア + 54 素晴らしい − 11 共有) | オーケストレーション インフラストラクチャ + 素晴らしいコア | `~/.codex/agents/` |
-| エージェントパック | 364 (282 パック + 82 素晴らしい) | 21 ドメイン カテゴリ + 素晴らしい ドメイン | `~/.codex/agent-packs/` |
-| スキル | 95 | ECC | `~/.codex/skills/` |
+| エージェントパック | 364 インストール済みファイル | `agent-packs/`, `agency/`, awesome 非コアカテゴリ | `~/.codex/agent-packs/` |
+| スキル | 125 | ECC | `~/.codex/skills/` |
 | config.toml | 1 | my-codex | `~/.codex/config.toml` |
 | AGENTS.md | 1 | my-codex | `~/.codex/AGENTS.md` |
 
@@ -173,7 +173,7 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 </details>
 
 <details>
-<summary>スキル (95) — Everything Claude Code から</summary>
+<summary>スキル (125) — Everything Claude Code から</summary>
 
 主要スキル：
 
@@ -223,10 +223,10 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 └──────┘ └────────┘ └────────┘ └────────┘
 ┌─────────────────────────────────────────────────────────┐
 │  Agent Layer (444 unique agents in native TOML)          │
-│    ├── Auto-loaded (80): 37 core + 54 awesome − 11 shared│
-│    └── Agent Packs (364): 282 packs + 82 awesome         │
+│    ├── Auto-loaded (80): final installed footprint       │
+│    └── Agent Packs (364): final installed footprint      │
 ├─────────────────────────────────────────────────────────┤
-│  Skills Layer (95 from ECC)                             │
+│  Skills Layer (125 from ECC)                            │
 │    ├── tdd-workflow, security-review, autopilot         │
 │    └── pdf, docx, pptx, xlsx, team                     │
 └─────────────────────────────────────────────────────────┘
@@ -301,7 +301,7 @@ Codex → spawn_agent("security-reviewer")
 ### 並列スポーン
 
 ```
-> Spawn 578 agents: refactor auth, add tests, review security
+> Run a multi-agent pass: refactor auth, add tests, review security
 
 Codex → spawn_agent("executor") × refactoring
       → spawn_agent("test-engineer") × test writing
@@ -347,7 +347,7 @@ Codex → spawn_agent("planner")
 
 ### 2. [Everything Claude Code (ECC)](https://github.com/affaan-m/everything-claude-code)
 
-もともと Claude Code 向けに構築された開発フレームワーク、95 スキルを提供します。13 個の Claude Code 固有スキルは削除されました。残りのスキルはすべてのLLM エージェント全体で使用可能な汎用コーディング ガイダンスを含みます。rules/ ディレクトリは参照資料としてリポジトリに含まれていますが、Codex CLI では読み取られません。
+もともと Claude Code 向けに構築された開発フレームワークで、125 スキルを提供します。13 個の Claude Code 固有スキルは削除されました。残りのスキルはすべての LLM エージェントで使用可能な汎用コーディング ガイダンスを含みます。rules/ ディレクトリは参照資料としてリポジトリに含まれていますが、Codex CLI では読み取られません。
 
 ### 3. [Awesome Codex Subagents](https://github.com/VoltAgent/awesome-codex-subagents)
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -14,13 +14,13 @@
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Agents](https://img.shields.io/badge/agents-444-blue)
-![Skills](https://img.shields.io/badge/skills-95-purple)
+![Skills](https://img.shields.io/badge/skills-125-purple)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
 ![Auto Sync](https://img.shields.io/badge/upstream_sync-weekly-brightgreen)
 
 OpenAI Codex CLI를 위한 올인원 멀티에이전트 오케스트레이션 — 한 번 설치하면 모든 것을 얻습니다.
 
-4개 업스트림 소스에서 **444개 에이전트** (80개 자동 로드 + 364개 에이전트팩)와 **95개 스킬**을 네이티브 TOML 형식으로 번들합니다. Codex CLI가 `spawn_agent`를 통해 에이전트를 자동 탐색하고 최적의 전문가에게 작업을 라우팅합니다. GitHub Actions CI가 매주 업스트림 변경사항을 동기화합니다.
+4개 업스트림 소스에서 **444개 설치 에이전트 파일** (80개 자동 로드 + 364개 에이전트팩)과 **125개 스킬**을 네이티브 TOML 형식으로 번들합니다. Codex CLI가 `spawn_agent`를 통해 에이전트를 자동 탐색하고 최적의 전문가에게 작업을 라우팅합니다. GitHub Actions CI가 매주 업스트림 변경사항을 동기화합니다.
 
 공식 [Codex Subagents](https://developers.openai.com/codex/subagents) 스펙 기반.
 
@@ -71,7 +71,7 @@ curl -s https://raw.githubusercontent.com/sehoon787/my-codex/main/AI-INSTALL.md
 - **o4-mini (low)**: 빠른 조회, 탐색 — Claude Haiku 동급에서 매핑
 
 ### 올인원 번들
-- 설치 시 **444개 에이전트와 95개 스킬** 즉시 제공
+- 설치 시 **444개 설치 에이전트 파일과 125개 스킬** 즉시 제공
 - 4개 업스트림 소스 번들 (agency-agents, everything-claude-code, oh-my-codex, awesome-codex-subagents)
 - 매주 CI 자동 동기화로 번들 콘텐츠를 업스트림 최신 상태로 유지
 - 비네이티브 소스의 MD→TOML 변환 자동 처리
@@ -148,8 +148,8 @@ rm ~/.codex/agents/<agent-name>.toml
 | 구성요소 | 수량 | 소스 | 위치 |
 |---------|------|------|------|
 | 자동 로드 에이전트 | 80 (37 코어 + 54 어썸 − 11 공유) | 오케스트레이션 인프라 + 어썸 코어 | `~/.codex/agents/` |
-| 에이전트 팩 | 364 (282 팩 + 82 어썸) | 21개 도메인 카테고리 + 어썸 도메인 | `~/.codex/agent-packs/` |
-| 스킬 | 95 | ECC | `~/.codex/skills/` |
+| 에이전트 팩 | 364 설치 파일 | `agent-packs/`, `agency/`, 어썸 비코어 카테고리 | `~/.codex/agent-packs/` |
+| 스킬 | 125 | ECC | `~/.codex/skills/` |
 | config.toml | 1 | my-codex | `~/.codex/config.toml` |
 | AGENTS.md | 1 | my-codex | `~/.codex/AGENTS.md` |
 
@@ -173,7 +173,7 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 </details>
 
 <details>
-<summary>스킬 (95개) — Everything Claude Code에서 제공</summary>
+<summary>스킬 (125개) — Everything Claude Code에서 제공</summary>
 
 주요 스킬:
 
@@ -223,10 +223,10 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 └──────┘ └────────┘ └────────┘ └────────┘
 ┌─────────────────────────────────────────────────────────┐
 │  에이전트 계층 (444개 고유 네이티브 TOML 에이전트)           │
-│    ├── 자동 로드 (80): 37 코어 + 54 어썸 − 11 공유         │
-│    └── 에이전트 팩 (364): 282 팩 + 82 어썸                 │
+│    ├── 자동 로드 (80): 최종 설치 기준                       │
+│    └── 에이전트 팩 (364): 최종 설치 기준                   │
 ├─────────────────────────────────────────────────────────┤
-│  스킬 계층 (ECC에서 95개)                                │
+│  스킬 계층 (ECC에서 125개)                               │
 │    ├── tdd-workflow, security-review, autopilot         │
 │    └── pdf, docx, pptx, xlsx, team                     │
 └─────────────────────────────────────────────────────────┘
@@ -347,7 +347,7 @@ Codex → spawn_agent("planner")
 
 ### 2. [Everything Claude Code (ECC)](https://github.com/affaan-m/everything-claude-code)
 
-원래 Claude Code용으로 제작된 개발 프레임워크로, 95개 스킬을 제공합니다. Claude Code 전용 스킬 13개를 제거했으며, 나머지 스킬은 모든 LLM 에이전트에서 활용 가능한 범용 코딩 가이드라인입니다. rules/ 디렉토리는 참고 자료로 저장소에 포함되어 있으나 Codex CLI가 읽지 않습니다.
+원래 Claude Code용으로 제작된 개발 프레임워크로, 125개 스킬을 제공합니다. Claude Code 전용 스킬 13개를 제거했으며, 나머지 스킬은 모든 LLM 에이전트에서 활용 가능한 범용 코딩 가이드라인입니다. rules/ 디렉토리는 참고 자료로 저장소에 포함되어 있으나 Codex CLI가 읽지 않습니다.
 
 ### 3. [Awesome Codex Subagents](https://github.com/VoltAgent/awesome-codex-subagents)
 

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -14,13 +14,13 @@
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Agents](https://img.shields.io/badge/agents-444-blue)
-![Skills](https://img.shields.io/badge/skills-95-purple)
+![Skills](https://img.shields.io/badge/skills-125-purple)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
 ![Auto Sync](https://img.shields.io/badge/upstream_sync-weekly-brightgreen)
 
 OpenAI Codex CLI 的一体化多智能体编排 — 一次安装，获得一切。
 
-将 **444 个智能体**（80 个自动加载 + 364 个智能体包）和 **95 个技能**从 4 个上游源整合为原生 TOML 格式。Codex CLI 通过 `spawn_agent` 自动发现智能体并将任务路由给最优专家。GitHub Actions CI 每周同步上游更改。
+将 **444 个已安装智能体文件**（80 个自动加载 + 364 个智能体包）和 **125 个技能**从 4 个上游源整合为原生 TOML 格式。Codex CLI 通过 `spawn_agent` 自动发现智能体并将任务路由给最优专家。GitHub Actions CI 每周同步上游更改。
 
 基于官方 [Codex Subagents](https://developers.openai.com/codex/subagents) 规范。
 
@@ -71,7 +71,7 @@ curl -s https://raw.githubusercontent.com/sehoon787/my-codex/main/AI-INSTALL.md
 - **o4-mini（低）**：快速查询、探索 — 从 Claude Haiku 等价体映射
 
 ### 一体化包
-- 安装即刻提供 **444 个智能体和 95 个技能**
+- 安装即刻提供 **444 个已安装智能体文件和 125 个技能**
 - 汇集 4 个上游源（agency-agents、everything-claude-code、oh-my-codex、awesome-codex-subagents）
 - 周期性 CI 自动同步保持捆绑内容与上游同步
 - MD-to-TOML 转换自动处理非原生源
@@ -107,7 +107,7 @@ test-engineer, qa-tester, multimodal-looker
 
 ## 智能体包（领域专家）
 
-282 个领域智能体跨 21 个类别安装到 `~/.codex/agent-packs/` — **默认不加载**。通过符号链接激活包：
+364 个已安装包文件跨 21 个类别写入 `~/.codex/agent-packs/` — **默认不加载**。通过符号链接激活包：
 
 ```bash
 # 激活单个包
@@ -148,8 +148,8 @@ rm ~/.codex/agents/<agent-name>.toml
 | 类别 | 数量 | 源 | 位置 |
 |------|------|------|------|
 | 自动加载的智能体 | 80（37 个核心 + 54 个 awesome − 11 个共享） | 编排基础设施 + awesome 核心 | `~/.codex/agents/` |
-| 智能体包 | 364（282 个包 + 82 个 awesome） | 21 个领域类别 + awesome 领域 | `~/.codex/agent-packs/` |
-| 技能 | 95 | ECC | `~/.codex/skills/` |
+| 智能体包 | 364 个已安装文件 | `agent-packs/`、`agency/`、awesome 非核心类别 | `~/.codex/agent-packs/` |
+| 技能 | 125 | ECC | `~/.codex/skills/` |
 | config.toml | 1 | my-codex | `~/.codex/config.toml` |
 | AGENTS.md | 1 | my-codex | `~/.codex/AGENTS.md` |
 
@@ -173,7 +173,7 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 </details>
 
 <details>
-<summary>技能 (95) — 来自 Everything Claude Code</summary>
+<summary>技能 (125) — 来自 Everything Claude Code</summary>
 
 关键技能包括：
 
@@ -223,10 +223,10 @@ agent-organizer, capability-assessor, conflict-resolver, context-manager, execut
 └──────┘ └────────┘ └────────┘ └────────┘
 ┌─────────────────────────────────────────────────────────┐
 │  Agent Layer (444 unique agents in native TOML)          │
-│    ├── Auto-loaded (80): 37 core + 54 awesome − 11 shared│
-│    └── Agent Packs (364): 282 packs + 82 awesome         │
+│    ├── Auto-loaded (80): final installed footprint       │
+│    └── Agent Packs (364): final installed footprint      │
 ├─────────────────────────────────────────────────────────┤
-│  Skills Layer (95 from ECC)                             │
+│  Skills Layer (125 from ECC)                            │
 │    ├── tdd-workflow, security-review, autopilot         │
 │    └── pdf, docx, pptx, xlsx, team                     │
 └─────────────────────────────────────────────────────────┘
@@ -301,7 +301,7 @@ Codex → spawn_agent("security-reviewer")
 ### 并行生成
 
 ```
-> Spawn 578 agents: refactor auth, add tests, review security
+> Run a multi-agent pass: refactor auth, add tests, review security
 
 Codex → spawn_agent("executor") × refactoring
       → spawn_agent("test-engineer") × test writing
@@ -347,7 +347,7 @@ Codex → spawn_agent("planner")
 
 ### 2. [Everything Claude Code (ECC)](https://github.com/affaan-m/everything-claude-code)
 
-最初为 Claude Code 构建的开发框架，提供 95 个技能。13 个 Claude Code 特定技能被移除；其余技能包含跨任何 LLM 智能体使用的通用编码指导。rules/ 目录包含在 repo 中作为参考材料，但不被 Codex CLI 读取。
+最初为 Claude Code 构建的开发框架，提供 125 个技能。13 个 Claude Code 特定技能被移除；其余技能包含可被任何 LLM 智能体复用的通用编码指导。rules/ 目录包含在 repo 中作为参考材料，但不被 Codex CLI 读取。
 
 ### 3. [Awesome Codex Subagents](https://github.com/VoltAgent/awesome-codex-subagents)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>my-codex — All-in-one Codex CLI Multi-Agent Orchestration</title>
-<meta name="description" content="All-in-one Codex CLI multi-agent orchestration toolkit. 578 agents (80 auto-loaded + 498 agent-packs), 125 skills, 3 MCP servers. From 4 curated upstream sources.">
+<meta name="description" content="All-in-one Codex CLI multi-agent orchestration toolkit. 444 installed agent files (80 auto-loaded + 364 agent-packs), 125 skills, 3 MCP servers. From 4 curated upstream sources.">
 <meta property="og:title" content="my-codex — All-in-one Codex CLI Multi-Agent Orchestration">
-<meta property="og:description" content="578 agents (80 auto-loaded + 498 agent-packs), 125 skills, 3 MCP servers from 4 curated upstream sources. Native TOML agents for OpenAI Codex CLI. One install gets everything.">
+<meta property="og:description" content="444 installed agent files (80 auto-loaded + 364 agent-packs), 125 skills, 3 MCP servers from 4 curated upstream sources. Native TOML agents for OpenAI Codex CLI. One install gets everything.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://sehoon787.github.io/my-codex/">
 <meta property="og:image" content="https://sehoon787.github.io/my-codex/assets/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="my-codex — Codex CLI Multi-Agent Orchestration Toolkit">
-<meta name="twitter:description" content="578 agents (80 auto-loaded + 498 agent-packs), 125 skills. Native TOML format for OpenAI Codex CLI.">
+<meta name="twitter:description" content="444 installed agent files (80 auto-loaded + 364 agent-packs), 125 skills. Native TOML format for OpenAI Codex CLI.">
 <link rel="canonical" href="https://sehoon787.github.io/my-codex/">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -210,9 +210,9 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
 </div>
   <h1><span class="lang" data-en="Every agent. One install." data-ko="모든 에이전트. 한 번의 설치."></span></h1>
   <p class="tagline">
-    <span class="lang" data-en="578 native TOML agents for OpenAI Codex CLI — curated from 4 upstream sources, auto-synced weekly. No conversion headaches." data-ko="OpenAI Codex CLI를 위한 578개 네이티브 TOML 에이전트 — 4개 업스트림 소스에서 큐레이션, 매주 자동 동기화. 변환 걱정 없음."></span>
+    <span class="lang" data-en="444 installed native TOML agent files for OpenAI Codex CLI — curated from 4 upstream sources, auto-synced weekly. No conversion headaches." data-ko="OpenAI Codex CLI를 위한 444개 설치 네이티브 TOML 에이전트 파일 — 4개 업스트림 소스에서 큐레이션, 매주 자동 동기화. 변환 걱정 없음."></span>
   </p>
-  <p class="stat-tagline"><em data-count="578">0</em> <span class="lang" data-en="agents" data-ko="에이전트"></span> · <em data-count="125">0</em> <span class="lang" data-en="skills" data-ko="스킬"></span> · <em>3</em> MCP</p>
+  <p class="stat-tagline"><em data-count="444">0</em> <span class="lang" data-en="agents" data-ko="에이전트"></span> · <em data-count="125">0</em> <span class="lang" data-en="skills" data-ko="스킬"></span> · <em>3</em> MCP</p>
   <div class="badges">
     <span class="badge"><span class="lang" data-en="Native TOML" data-ko="네이티브 TOML"></span></span>
     <span class="badge"><span class="lang" data-en="4 Upstream Sources" data-ko="4개 업스트림 소스"></span></span>
@@ -236,7 +236,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
     <div class="card fade-in">
       <span class="card-icon">&#x1f4e6;</span>
       <h3><span class="lang" data-en="Native TOML" data-ko="네이티브 TOML"></span></h3>
-      <p><span class="lang" data-en="All 578 agents in Codex CLI's native .toml format. No runtime conversion, no compatibility shims, no surprises. What you install is what runs." data-ko="578개 에이전트 모두 Codex CLI 네이티브 .toml 형식. 런타임 변환 없음, 호환성 심 없음, 예상치 못한 문제 없음. 설치한 것이 그대로 실행됩니다."></span></p>
+      <p><span class="lang" data-en="All 444 installed agent files are in Codex CLI's native .toml format. No runtime conversion, no compatibility shims, no surprises. What you install is what runs." data-ko="설치되는 444개 에이전트 파일 모두 Codex CLI 네이티브 .toml 형식입니다. 런타임 변환 없음, 호환성 심 없음, 예상치 못한 문제 없음. 설치한 것이 그대로 실행됩니다."></span></p>
     </div>
     <div class="card fade-in">
       <span class="card-icon">&#x1f504;</span>
@@ -275,10 +275,10 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
           <div class="term-line t-src">[sync] <span class="lang" data-en="awesome-codex-subagents → 136 agents (native TOML)" data-ko="awesome-codex-subagents → 136개 에이전트 (네이티브 TOML)"></span></div>
           <div class="term-line t-phase">── <span class="lang" data-en="Installing" data-ko="설치 중"></span> ──</div>
           <div class="term-line t-ok">&#x2713; <span class="lang" data-en="37 core agents + 136 awesome agents → ~/.codex/agents/" data-ko="37개 코어 에이전트 + 136개 어썸 에이전트 → ~/.codex/agents/"></span></div>
-          <div class="term-line t-ok">&#x2713; <span class="lang" data-en="282 agent-packs → ~/.codex/agent-packs/" data-ko="282개 에이전트팩 → ~/.codex/agent-packs/"></span></div>
+          <div class="term-line t-ok">&#x2713; <span class="lang" data-en="364 agent-packs → ~/.codex/agent-packs/" data-ko="364개 에이전트팩 → ~/.codex/agent-packs/"></span></div>
           <div class="term-line t-ok">&#x2713; <span class="lang" data-en="125 skills installed" data-ko="125개 스킬 설치 완료"></span></div>
           <div class="term-line t-ok">&#x2713; <span class="lang" data-en="AGENTS.md + config.toml configured" data-ko="AGENTS.md + config.toml 설정 완료"></span></div>
-          <div class="term-line t-acc"><span class="lang" data-en="Done. 578 agents ready." data-ko="완료. 578개 에이전트 준비됨."></span></div>
+          <div class="term-line t-acc"><span class="lang" data-en="Done. 444 installed agent files ready." data-ko="완료. 444개 설치 에이전트 파일 준비됨."></span></div>
         </div>
         <div class="term-scene" data-scene="1">
           <div class="term-line t-dim">$ codex "<span class="lang" data-en="refactor auth module and review it" data-ko="auth 모듈 리팩토링하고 리뷰해줘"></span>"</div>
@@ -331,7 +331,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
     <div class="pipe-card" style="border-color:#a855f7;background:rgba(168,85,247,.06)">
       <h4 style="color:#a855f7"><span class="lang" data-en="Package" data-ko="패키징"></span></h4>
       <p><span class="lang" data-en="auto-loaded + agent-packs + skills" data-ko="자동 로드 + 에이전트팩 + 스킬"></span></p>
-      <div class="ex">80 + 498 + 125</div>
+      <div class="ex">80 + 364 + 125</div>
     </div>
     <div class="pipe-card" style="border-color:var(--green);background:rgba(52,211,153,.06)">
       <h4 style="color:var(--green)"><span class="lang" data-en="Deliver" data-ko="배포"></span></h4>
@@ -364,7 +364,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
         <p>~/.codex/agents/</p>
       </div>
       <div class="arch-layer">
-        <h4 style="color:var(--pink)"><span class="lang" data-en="Agent Packs" data-ko="에이전트 팩"></span><span class="cnt">282</span></h4>
+        <h4 style="color:var(--pink)"><span class="lang" data-en="Agent Packs" data-ko="에이전트 팩"></span><span class="cnt">364</span></h4>
         <p>~/.codex/agent-packs/</p>
       </div>
       <div class="arch-layer">
@@ -392,7 +392,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
 <section id="catalog">
 <div class="container">
   <h2 class="st"><span class="lang" data-en="Agent Catalog" data-ko="에이전트 목록"></span></h2>
-  <p class="ss"><span class="lang" data-en="578 agents organized into auto-loaded (daily use) and agent-packs (domain specialists), all in native TOML." data-ko="578개 에이전트를 자동 로드(일상 사용)와 에이전트팩(도메인 전문가)으로 구성, 모두 네이티브 TOML."></span></p>
+  <p class="ss"><span class="lang" data-en="444 installed agent files organized into auto-loaded (daily use) and agent-packs (domain specialists), all in native TOML." data-ko="444개 설치 에이전트 파일을 자동 로드(일상 사용)와 에이전트팩(도메인 전문가)으로 구성, 모두 네이티브 TOML."></span></p>
   <div class="catalog fade-in">
     <details>
       <summary><span class="lang" data-en="Core — Development" data-ko="코어 — 개발"></span> <span class="cat-count">~10 agents</span></summary>
@@ -463,7 +463,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
     </details>
     <details>
       <summary><span class="lang" data-en="Agent Packs — Education, Healthcare &amp; More" data-ko="에이전트 팩 — 교육, 의료 및 기타"></span> <span class="cat-count">~15 agents</span></summary>
-      <div class="cat-body"><span class="lang" data-en="Curriculum designer, e-learning developer, medical advisor, clinical trial analyst, research assistant, academic writer, grant writer, plus multi-platform agent harness from oh-my-openagent. All 498 packs in ~/.codex/agent-packs/." data-ko="커리큘럼 디자이너, e-러닝 개발자, 의료 자문, 임상 시험 분석가, 연구 보조원, 학술 작가, 연구비 지원서 작가, oh-my-openagent의 멀티플랫폼 에이전트 하네스 포함. 전체 498개 팩이 ~/.codex/agent-packs/에."></span></div>
+      <div class="cat-body"><span class="lang" data-en="Curriculum designer, e-learning developer, medical advisor, clinical trial analyst, research assistant, academic writer, grant writer, plus multi-platform agent harness from oh-my-openagent. All 364 installed pack files land in ~/.codex/agent-packs/ after deduplication." data-ko="커리큘럼 디자이너, e-러닝 개발자, 의료 자문, 임상 시험 분석가, 연구 보조원, 학술 작가, 연구비 지원서 작가, oh-my-openagent의 멀티플랫폼 에이전트 하네스 포함. 중복 정리 후 전체 364개 팩 파일이 ~/.codex/agent-packs/에 설치됩니다."></span></div>
     </details>
   </div>
 </div>
@@ -505,7 +505,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
   </div>
   <table class="cmp-tbl fade-in">
     <tr><th><span class="lang" data-en="Feature" data-ko="기능"></span></th><th>my-codex</th><th><span class="lang" data-en="Manual Setup" data-ko="수동 설정"></span></th><th><span class="lang" data-en="Other Collections" data-ko="다른 컬렉션"></span></th></tr>
-    <tr><td><span class="lang" data-en="Native TOML Agents" data-ko="네이티브 TOML 에이전트"></span></td><td class="y">&#x2705; 578</td><td class="n">&#x2717;</td><td>Custom</td></tr>
+    <tr><td><span class="lang" data-en="Native TOML Agents" data-ko="네이티브 TOML 에이전트"></span></td><td class="y">&#x2705; 444</td><td class="n">&#x2717;</td><td>Custom</td></tr>
     <tr><td><span class="lang" data-en="Multi-source Curation" data-ko="멀티소스 큐레이션"></span></td><td class="y">&#x2705; 4 sources</td><td class="n">&#x2717;</td><td class="n">&#x2717;</td></tr>
     <tr><td><span class="lang" data-en="Weekly Auto-sync" data-ko="매주 자동 동기화"></span></td><td class="y">&#x2705;</td><td class="n">&#x2717;</td><td class="n">&#x2717;</td></tr>
     <tr><td><span class="lang" data-en="Skills included" data-ko="스킬 포함"></span></td><td class="y">&#x2705; 125</td><td>Custom</td><td class="n">&#x2717;</td></tr>
@@ -522,7 +522,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
   <div class="faq fade-in">
     <div class="faq-item">
       <button class="faq-q" onclick="toggleFaq(this)"><span class="lang" data-en="What is my-codex?" data-ko="my-codex란?"></span><span></span></button>
-      <div class="faq-a"><div class="faq-a-inner"><span class="lang" data-en="my-codex is the definitive agent collection for OpenAI Codex CLI. It aggregates 578 agents from 4 curated upstream sources, all in native TOML format. It's the sister project of my-claude (for Claude Code)." data-ko="my-codex는 OpenAI Codex CLI를 위한 최고의 에이전트 컬렉션입니다. 4개 큐레이션된 업스트림 소스에서 578개 에이전트를 네이티브 TOML 형식으로 통합합니다. my-claude(Claude Code용)의 자매 프로젝트입니다."></span></div></div>
+      <div class="faq-a"><div class="faq-a-inner"><span class="lang" data-en="my-codex is the definitive agent collection for OpenAI Codex CLI. It aggregates 4 curated upstream sources into 444 installed agent files and 125 skills, all in native TOML format. It's the sister project of my-claude (for Claude Code)." data-ko="my-codex는 OpenAI Codex CLI를 위한 최고의 에이전트 컬렉션입니다. 4개 큐레이션된 업스트림 소스를 네이티브 TOML 형식의 444개 설치 에이전트 파일과 125개 스킬로 통합합니다. my-claude(Claude Code용)의 자매 프로젝트입니다."></span></div></div>
     </div>
     <div class="faq-item">
       <button class="faq-q" onclick="toggleFaq(this)"><span class="lang" data-en="How does auto-sync work?" data-ko="자동 동기화는 어떻게 동작하나요?"></span><span></span></button>
@@ -552,7 +552,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
 <section id="install" style="background:var(--bg2)">
 <div class="container">
   <h2 class="st"><span class="lang" data-en="Quick Install" data-ko="빠른 설치"></span></h2>
-  <p class="ss"><span class="lang" data-en="One command to install everything — 578 agents, 125 skills." data-ko="명령어 하나로 모든 것을 설치하세요 — 578개 에이전트, 125개 스킬."></span></p>
+  <p class="ss"><span class="lang" data-en="One command to install everything — 444 installed agent files, 125 skills." data-ko="명령어 하나로 모든 것을 설치하세요 — 444개 설치 에이전트 파일, 125개 스킬."></span></p>
   <div class="inst-row fade-in">
     <div class="inst">
       <h4><span class="lang" data-en="Script Install" data-ko="스크립트 설치"></span></h4>

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/scripts/compute-install-counts.sh")"
 
 echo "=== my-codex installer ==="
+echo ""
+echo "Expected install footprint: ${INSTALLED_AGENT_TOTAL} agents (${AUTO_LOADED_COUNT} auto-loaded + ${AGENT_PACK_COUNT} agent-packs), ${SKILL_COUNT} skills"
+echo "Source inventory: ${SOURCE_TOML_COUNT} TOML definitions before install-time deduplication"
 echo ""
 
 # ── 0. Prerequisites ──
@@ -42,7 +46,7 @@ fi
 if [ -d "$SCRIPT_DIR/codex-agents/awesome-core" ]; then
   cp "$SCRIPT_DIR/codex-agents/awesome-core/"*.toml "$HOME/.codex/agents/" 2>/dev/null || true
 fi
-echo "  Core agents: $(find "$HOME/.codex/agents" -maxdepth 1 -name '*.toml' | wc -l | tr -d ' ') installed"
+echo "  Core agents: $(find "$HOME/.codex/agents" -maxdepth 1 -name '*.toml' | wc -l | tr -d ' ') installed (expected ${AUTO_LOADED_COUNT})"
 
 # Agency agents (upstream MD→TOML converted, domain specialists)
 if [ -d "$SCRIPT_DIR/codex-agents/agency" ]; then
@@ -62,7 +66,7 @@ for cat_dir in "$SCRIPT_DIR/codex-agents/agent-packs/"*/; do
   mkdir -p "$HOME/.codex/agent-packs/$cat_name"
   cp "$cat_dir"*.toml "$HOME/.codex/agent-packs/$cat_name/" 2>/dev/null || true
 done
-echo "  Agent packs: $(find "$HOME/.codex/agent-packs" -name '*.toml' | wc -l | tr -d ' ') installed"
+echo "  Agent packs: $(find "$HOME/.codex/agent-packs" -name '*.toml' | wc -l | tr -d ' ') installed (expected ${AGENT_PACK_COUNT})"
 
 # Awesome Codex Subagents (native TOML — add to core)
 if [ -d "$SCRIPT_DIR/codex-agents/awesome" ]; then
@@ -88,9 +92,9 @@ echo "[2/7] Installing skills..."
 mkdir -p "$HOME/.codex/skills"
 # Note: Codex scans ~/.codex/skills/ for SKILL.md files
 if [ -d "$SCRIPT_DIR/skills" ]; then
-  cp -r "$SCRIPT_DIR/skills/ecc/"* "$HOME/.codex/skills/" 2>/dev/null || true
+  cp -R "$SCRIPT_DIR/skills/ecc/." "$HOME/.codex/skills/" 2>/dev/null || true
 fi
-echo "  Skills: $(find "$HOME/.codex/skills" -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ') installed"
+echo "  Skills: $(find "$HOME/.codex/skills" -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ') installed (expected ${SKILL_COUNT})"
 
 # ── 3. Global AGENTS.md ──
 echo "[3/7] Setting up AGENTS.md..."
@@ -126,10 +130,20 @@ fi
 # ── 5. MCP servers ──
 echo "[5/7] Registering MCP servers..."
 if command -v codex >/dev/null 2>&1; then
-  codex mcp add context7  --url https://mcp.context7.com/mcp 2>/dev/null || true
-  codex mcp add exa       --url "https://mcp.exa.ai/mcp?tools=web_search_exa" 2>/dev/null || true
-  codex mcp add grep_app  --url https://mcp.grep.app 2>/dev/null || true
-  echo "  3 MCP servers registered (context7, exa, grep_app)"
+  MCP_LIST="$(codex mcp list 2>/dev/null || true)"
+  ensure_mcp_server() {
+    local name=$1
+    shift
+    if printf '%s\n' "$MCP_LIST" | grep -qE "^${name}[[:space:]]"; then
+      echo "  ${name} already registered"
+      return
+    fi
+    codex mcp add "$name" "$@" 2>/dev/null || echo "  WARNING: failed to register ${name}"
+  }
+  ensure_mcp_server context7 --url https://mcp.context7.com/mcp
+  ensure_mcp_server exa --url "https://mcp.exa.ai/mcp?tools=web_search_exa"
+  ensure_mcp_server grep_app --url https://mcp.grep.app
+  echo "  MCP registration checked (context7, exa, grep_app)"
 else
   echo "  codex not found — MCP servers will be registered when codex is installed"
 fi
@@ -148,9 +162,10 @@ fi
 # ── 7. Verification ──
 echo ""
 echo "[7/7] Verification"
-echo "  Core agents:   $(find "$HOME/.codex/agents" -name '*.toml' 2>/dev/null | wc -l | tr -d ' ') files"
-echo "  Agent packs:   $(find "$HOME/.codex/agent-packs" -name '*.toml' 2>/dev/null | wc -l | tr -d ' ') files"
-echo "  Skills:        $(find "$HOME/.codex/skills" -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ') installed"
+echo "  Source TOML:   ${SOURCE_TOML_COUNT} definitions"
+echo "  Core agents:   $(find "$HOME/.codex/agents" -name '*.toml' 2>/dev/null | wc -l | tr -d ' ') files (expected ${AUTO_LOADED_COUNT})"
+echo "  Agent packs:   $(find "$HOME/.codex/agent-packs" -name '*.toml' 2>/dev/null | wc -l | tr -d ' ') files (expected ${AGENT_PACK_COUNT})"
+echo "  Skills:        $(find "$HOME/.codex/skills" -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ') installed (expected ${SKILL_COUNT})"
 echo "  AGENTS.md:     $(test -f "$HOME/.codex/AGENTS.md" && echo 'OK' || echo 'MISSING')"
 echo "  config.toml:   $(grep -q 'multi_agent' "$HOME/.codex/config.toml" 2>/dev/null && echo 'OK' || echo 'NEEDS CONFIG')"
 echo "  codex:         $(command -v codex >/dev/null 2>&1 && echo "OK ($(codex --version 2>/dev/null))" || echo 'NOT INSTALLED')"

--- a/scripts/compute-install-counts.sh
+++ b/scripts/compute-install-counts.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="${TMPDIR:-/tmp}/my-codex-counts.$$"
+INSTALL_ROOT="$TMP_ROOT/install"
+AGENTS_DIR="$INSTALL_ROOT/agents"
+PACKS_DIR="$INSTALL_ROOT/agent-packs"
+SKILLS_DIR="$INSTALL_ROOT/skills"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$AGENTS_DIR" "$PACKS_DIR" "$SKILLS_DIR"
+
+copy_glob() {
+  local pattern=$1
+  local dest=$2
+  local matches=()
+
+  shopt -s nullglob
+  matches=($pattern)
+  shopt -u nullglob
+
+  if [ ${#matches[@]} -gt 0 ]; then
+    cp "${matches[@]}" "$dest/"
+  fi
+}
+
+copy_glob "$SCRIPT_DIR/codex-agents/core/*.toml" "$AGENTS_DIR"
+copy_glob "$SCRIPT_DIR/codex-agents/omo/*.toml" "$AGENTS_DIR"
+copy_glob "$SCRIPT_DIR/codex-agents/omc/*.toml" "$AGENTS_DIR"
+copy_glob "$SCRIPT_DIR/codex-agents/awesome-core/*.toml" "$AGENTS_DIR"
+
+for cat_dir in "$SCRIPT_DIR/codex-agents/agency/"*/; do
+  [ -d "$cat_dir" ] || continue
+  cat_name=$(basename "$cat_dir")
+  mkdir -p "$PACKS_DIR/$cat_name"
+  copy_glob "${cat_dir}*.toml" "$PACKS_DIR/$cat_name"
+done
+
+for cat_dir in "$SCRIPT_DIR/codex-agents/agent-packs/"*/; do
+  [ -d "$cat_dir" ] || continue
+  cat_name=$(basename "$cat_dir")
+  mkdir -p "$PACKS_DIR/$cat_name"
+  copy_glob "${cat_dir}*.toml" "$PACKS_DIR/$cat_name"
+done
+
+for cat_dir in "$SCRIPT_DIR/codex-agents/awesome/"*/; do
+  [ -d "$cat_dir" ] || continue
+  cat_name=$(basename "$cat_dir")
+  case "$cat_name" in
+    01-core-development|03-infrastructure|04-quality-security|09-meta-orchestration)
+      copy_glob "${cat_dir}*.toml" "$AGENTS_DIR"
+      ;;
+    *)
+      mkdir -p "$PACKS_DIR/$cat_name"
+      copy_glob "${cat_dir}*.toml" "$PACKS_DIR/$cat_name"
+      ;;
+  esac
+done
+
+if [ -d "$SCRIPT_DIR/skills/ecc" ]; then
+  cp -R "$SCRIPT_DIR/skills/ecc/." "$SKILLS_DIR/"
+fi
+
+AUTO_LOADED_COUNT=$(find "$AGENTS_DIR" -name '*.toml' | wc -l | tr -d ' ')
+AGENT_PACK_COUNT=$(find "$PACKS_DIR" -name '*.toml' | wc -l | tr -d ' ')
+SKILL_COUNT=$(find "$SKILLS_DIR" -name 'SKILL.md' | wc -l | tr -d ' ')
+INSTALLED_AGENT_TOTAL=$((AUTO_LOADED_COUNT + AGENT_PACK_COUNT))
+SOURCE_TOML_COUNT=$(find "$SCRIPT_DIR/codex-agents" -name '*.toml' | wc -l | tr -d ' ')
+
+cat <<EOF
+AUTO_LOADED_COUNT=$AUTO_LOADED_COUNT
+AGENT_PACK_COUNT=$AGENT_PACK_COUNT
+SKILL_COUNT=$SKILL_COUNT
+INSTALLED_AGENT_TOTAL=$INSTALLED_AGENT_TOTAL
+SOURCE_TOML_COUNT=$SOURCE_TOML_COUNT
+EOF

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="${TMPDIR:-/tmp}/my-codex-install-test.$$"
+TEST_HOME="$TMP_ROOT/home"
+BIN_DIR="$TMP_ROOT/bin"
+LOG_FILE="$TMP_ROOT/codex.log"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TEST_HOME" "$BIN_DIR"
+
+cat > "$BIN_DIR/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${MY_CODEX_TEST_LOG:?}"
+case "${1:-}" in
+  --version)
+    echo "codex-test"
+    ;;
+  mcp)
+    if [ "${2:-}" = "add" ]; then
+      echo "$*" >> "$LOG_FILE"
+      exit 0
+    fi
+    ;;
+esac
+echo "$*" >> "$LOG_FILE"
+EOF
+chmod +x "$BIN_DIR/codex"
+
+cat > "$BIN_DIR/npm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${MY_CODEX_TEST_LOG:?}"
+exit 0
+EOF
+chmod +x "$BIN_DIR/npm"
+
+cat > "$BIN_DIR/ast-grep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$BIN_DIR/ast-grep"
+
+eval "$("$REPO_ROOT/scripts/compute-install-counts.sh")"
+
+HOME="$TEST_HOME" PATH="$BIN_DIR:$PATH" MY_CODEX_TEST_LOG="$LOG_FILE" \
+  bash "$REPO_ROOT/install.sh" > "$TMP_ROOT/install.out"
+
+actual_auto=$(find "$TEST_HOME/.codex/agents" -name '*.toml' | wc -l | tr -d ' ')
+actual_packs=$(find "$TEST_HOME/.codex/agent-packs" -name '*.toml' | wc -l | tr -d ' ')
+actual_skills=$(find "$TEST_HOME/.codex/skills" -name 'SKILL.md' | wc -l | tr -d ' ')
+
+test "$actual_auto" = "$AUTO_LOADED_COUNT"
+test "$actual_packs" = "$AGENT_PACK_COUNT"
+test "$actual_skills" = "$SKILL_COUNT"
+test -f "$TEST_HOME/.codex/AGENTS.md"
+grep -q 'multi_agent = true' "$TEST_HOME/.codex/config.toml"
+grep -q 'child_agents_md = true' "$TEST_HOME/.codex/config.toml"
+grep -q 'max_threads = 8' "$TEST_HOME/.codex/config.toml"
+
+grep -q 'mcp add context7' "$LOG_FILE"
+grep -q 'mcp add exa' "$LOG_FILE"
+grep -q 'mcp add grep_app' "$LOG_FILE"
+
+echo "Install smoke test passed"


### PR DESCRIPTION
## Summary
- Align hardcoded counts in AI-INSTALL.md, README.md, SETUP.md, i18n docs, and landing page with actual agent/skill/rule counts
- Add `scripts/compute-install-counts.sh` and `scripts/test-install.sh` for verifiable count checking
- Fix sync-upstream.yml and CI workflow to keep counts synchronized

## Changed files
- `AI-INSTALL.md`, `README.md`, `SETUP.md` — corrected counts
- `docs/i18n/README.*.md` — aligned translations
- `docs/index.html` — restored individual category counts
- `install.sh` — verification section updated
- `.github/workflows/sync-upstream.yml`, `ci.yml` — count automation
- `scripts/compute-install-counts.sh`, `scripts/test-install.sh` — new verification scripts

## Test plan
- [x] Local smoke test of sed patterns
- [x] Verified counts match actual file counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)