### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,28 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@1c30734416d9b05948ccd7f4b3cf60baada87e9e
+        with:
+          mode: validate


### PR DESCRIPTION
Adding a validate-only workflow for skill metadata validation.

- 3-Phase Sprint with interactive design and review phases
- Agent Telemetry via PostToolUse hook for analytics logging
- Specialized coverage across Legal, Finance, Healthcare, and Workflow

This PR adds one workflow file that runs the HOL skill validator in validate mode. It checks schema and trust signals only, stays validate-only, and leaves runtime code untouched.

Let me know if you'd prefer a different workflow filename or skill directory path.