### PR TITLE
fix: use a real 5.6 slug for HIGH tier and make in-place edits portable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -543,30 +543,67 @@ copy_toml_dir() {
   done
 }
 
+# Portable in-place sed.
+#
+# GNU sed takes `-i` with no argument; BSD sed (the /usr/bin/sed on macOS)
+# requires an explicit backup suffix, so bare `sed -i "s/x/y/" f` there eats
+# the script as the suffix and dies with "unescaped newline inside substitute
+# pattern" — silently leaving the file untouched. Every in-place edit in this
+# script MUST go through this wrapper.
+sed_inplace() {
+  if sed --version >/dev/null 2>&1; then
+    sed -i "$@"        # GNU
+  else
+    sed -i '' "$@"     # BSD / macOS
+  fi
+}
+
+# Portable "insert LINE after the first line matching PATTERN".
+#
+# sed's append is the one command whose syntax genuinely differs between
+# implementations (GNU takes `a text` inline; BSD demands `a\` then the text
+# on the next line), so neither form is portable even through sed_inplace.
+# awk behaves identically on both.
+#   $1 = ERE pattern, $2 = line to insert, $3 = file
+insert_after() {
+  local _tmp="$3.tmp.$$"
+  awk -v pat="$1" -v ins="$2" '
+    { print }
+    !inserted && $0 ~ pat { print ins; inserted = 1 }
+  ' "$3" > "$_tmp" && mv "$_tmp" "$3"
+}
+
 # Normalize legacy/upstream-native model values to current tiers (see
 # scripts/model-tiers.sh). Some sources (e.g. the vendored agent packs in
 # codex-agents/packs/) ship native .toml agents with their own model value,
 # bypassing md-to-toml.sh's map_model tiering.
 normalize_agent_models() {
   local dir="$1"
-  local legacy_workhorse legacy_spark
+  local entry from tier to count summary=""
   [ -d "$dir" ] || return 0
 
-  legacy_workhorse=$({ grep -rl "^model = \"$LEGACY_WORKHORSE_MODEL\"\$" "$dir" --include='*.toml' 2>/dev/null || true; } | wc -l | tr -d ' ')
-  if [ "$legacy_workhorse" -gt 0 ]; then
-    grep -rl "^model = \"$LEGACY_WORKHORSE_MODEL\"\$" "$dir" --include='*.toml' 2>/dev/null | while IFS= read -r f; do
-      sed -i "s/^model = \"$LEGACY_WORKHORSE_MODEL\"\$/model = \"$MODEL_TIER_MEDIUM\"/" "$f"
-    done
-  fi
+  for entry in "${LEGACY_MODEL_MAP[@]}"; do
+    from="${entry%:*}"
+    tier="${entry##*:}"
+    case "$tier" in
+      HIGH)   to="$MODEL_TIER_HIGH" ;;
+      MEDIUM) to="$MODEL_TIER_MEDIUM" ;;
+      LOW)    to="$MODEL_TIER_LOW" ;;
+      *)      continue ;;
+    esac
+    # A tier promoted to its own current value has nothing to rewrite.
+    [ "$from" = "$to" ] && continue
 
-  legacy_spark=$({ grep -rl "^model = \"$LEGACY_SPARK_MODEL\"\$" "$dir" --include='*.toml' 2>/dev/null || true; } | wc -l | tr -d ' ')
-  if [ "$legacy_spark" -gt 0 ]; then
-    grep -rl "^model = \"$LEGACY_SPARK_MODEL\"\$" "$dir" --include='*.toml' 2>/dev/null | while IFS= read -r f; do
-      sed -i "s/^model = \"$LEGACY_SPARK_MODEL\"\$/model = \"$MODEL_TIER_LOW\"/" "$f"
-    done
-  fi
+    count=$({ grep -rl "^model = \"$from\"\$" "$dir" --include='*.toml' 2>/dev/null || true; } | wc -l | tr -d ' ')
+    if [ "$count" -gt 0 ]; then
+      grep -rl "^model = \"$from\"\$" "$dir" --include='*.toml' 2>/dev/null | while IFS= read -r f; do
+        sed_inplace "s/^model = \"$from\"\$/model = \"$to\"/" "$f"
+      done
+    fi
+    summary="$summary ${count} ${from}->${to};"
+  done
 
-  echo "  Normalized $dir: $legacy_workhorse $LEGACY_WORKHORSE_MODEL -> $MODEL_TIER_MEDIUM, $legacy_spark $LEGACY_SPARK_MODEL -> $MODEL_TIER_LOW"
+  echo "  Normalized $dir:$summary"
 }
 
 # Records one directory entry ("skills/<name>") per copied tree, not one line
@@ -966,15 +1003,13 @@ if [ "$SKIP_OMX" = "0" ]; then
         if ! grep -q '^name:' "$md_file" 2>/dev/null; then
           cp "$md_file" "$omc_staging/omc/$bname"
           # Insert name: after first ---
-          sed -i "1,/^---$/{/^---$/a\\
-name: $fname
-}" "$omc_staging/omc/$bname" 2>/dev/null || true
+          insert_after '^---$' "name: $fname" "$omc_staging/omc/$bname" 2>/dev/null || true
         else
           cp "$md_file" "$omc_staging/omc/$bname"
         fi
         # Add model: if missing
         if ! grep -q '^model:' "$omc_staging/omc/$bname" 2>/dev/null; then
-          sed -i "/^description:/a model: $MODEL_TIER_HIGH" "$omc_staging/omc/$bname" 2>/dev/null || true
+          insert_after '^description:' "model: $MODEL_TIER_HIGH" "$omc_staging/omc/$bname" 2>/dev/null || true
         fi
       done
       omc_toml_out="$CLONE_TMPDIR/omc-toml"

--- a/scripts/model-tiers.sh
+++ b/scripts/model-tiers.sh
@@ -9,7 +9,15 @@
 # model ID outside of this file (see scripts/check-model-drift.sh).
 
 # Codex model ID per tier.
-MODEL_TIER_HIGH="gpt-5.6"
+#
+# Every value here MUST be a slug the Codex API actually serves. The 5.6
+# generation ships only suffixed slugs (sol/terra/luna) — a bare "gpt-5.6"
+# is NOT a real model and fails at request time with:
+#   400 invalid_request_error: The 'gpt-5.6' model is not supported when
+#   using Codex with a ChatGPT account.
+# Verify against `~/.codex/models_cache.json` (visibility="list") before
+# rolling these forward.
+MODEL_TIER_HIGH="gpt-5.6-sol"
 MODEL_TIER_MEDIUM="gpt-5.6-terra"
 MODEL_TIER_LOW="gpt-5.6-luna"
 
@@ -23,3 +31,20 @@ MODEL_TIER_LOW_EFFORT="low"
 # with these stale values baked in).
 LEGACY_WORKHORSE_MODEL="gpt-5.4"          # -> MODEL_TIER_MEDIUM
 LEGACY_SPARK_MODEL="gpt-5.3-codex-spark"  # -> MODEL_TIER_LOW
+
+# Full rewrite table consumed by normalize_agent_models(). Format: "from:TIER"
+# where TIER is HIGH|MEDIUM|LOW, resolved against MODEL_TIER_* above.
+#
+# Two distinct classes live here:
+#   1. Superseded-but-still-served slugs (gpt-5.4, gpt-5.5) — promoted so the
+#      install tracks the current generation.
+#   2. Slugs that were never valid (bare gpt-5.6) — these HARD FAIL at request
+#      time, so rewriting them repairs installs made while that value shipped
+#      as MODEL_TIER_HIGH.
+LEGACY_MODEL_MAP=(
+  "$LEGACY_WORKHORSE_MODEL:MEDIUM"
+  "$LEGACY_SPARK_MODEL:LOW"
+  "gpt-5.5:HIGH"
+  "gpt-5.5-codex:HIGH"
+  "gpt-5.6:HIGH"
+)


### PR DESCRIPTION
Two defects that together left macOS installs on stale or invalid models.

## 1. `MODEL_TIER_HIGH` pointed at a model that does not exist

`gpt-5.6` is not a slug the API serves — the 5.6 generation ships only suffixed variants. Every agent installed at the HIGH tier therefore failed at request time:

```
400 invalid_request_error: The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account.
```

Verified against the live API on this machine:

| model | result |
|---|---|
| `gpt-5.6-sol` | OK |
| `gpt-5.5` | OK |
| `gpt-5.6` | **400 — not supported** |

`~/.codex/models_cache.json` (fetched today, client 0.147.0) lists exactly: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`. HIGH is now **`gpt-5.6-sol`**; MEDIUM and LOW were already correct.

## 2. `normalize_agent_models()` never ran on macOS

It used GNU-style `sed -i "s/..." file`. BSD sed (`/usr/bin/sed`) reads the next token as the backup suffix and fails:

```
sed: 1: "a.toml": unescaped newline inside substitute pattern
```

The file is left untouched — which is why installs accumulated the very `gpt-5.4` / `gpt-5.3-codex-spark` values the normalizer exists to rewrite. Added `sed_inplace()`, which detects the implementation once.

The two `sed -i ".../a text"` append sites are worse: GNU takes the text inline, BSD requires `a\` plus a following line, so **no single sed form is portable**. Replaced with `insert_after()`, an awk helper identical on both. One of those sites injects `model:` — so model assignment itself was silently failing.

## Rewrite table

Moved to `LEGACY_MODEL_MAP` in `model-tiers.sh`, keeping tier mapping in one place. It now also repairs installs that captured the invalid bare `gpt-5.6` while it shipped as `MODEL_TIER_HIGH`.

## Verification (macOS, BSD sed/awk, bash 3.2)

Live `normalize_agent_models()` run:

| before | after |
|---|---|
| `gpt-5.4` | `gpt-5.6-terra` |
| `gpt-5.3-codex-spark` | `gpt-5.6-luna` |
| `gpt-5.5` | `gpt-5.6-sol` |
| `gpt-5.6` | `gpt-5.6-sol` |
| `gpt-5.6-terra` | unchanged |

- `insert_after()` places `name:` / `model:` at the correct lines
- model-drift scan clean outside excluded paths
- `bash -n` passes on both files

Note: `check-model-drift.sh` and `scan-upstream-diff.sh` use `mapfile` (bash 4+), so they cannot run under macOS bash 3.2. Both are CI-only, so this is out of scope here — the drift check above was reproduced manually with the same pattern.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p