### PR TITLE
fix(agents): pin a valid HIGH-tier slug and stop silently demoting agents

### DIFF
--- a/codex-agents/core/boss.toml
+++ b/codex-agents/core/boss.toml
@@ -1,6 +1,6 @@
 name = "boss"
 description = "Use when the user's request needs dynamic agent discovery, intent classification, and delegation to the optimal specialist."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/atlas.toml
+++ b/codex-agents/omo/atlas.toml
@@ -1,6 +1,6 @@
 name = "atlas"
 description = "Use when a work plan already exists and each step needs delegation, sequencing, and verification; returns a task-by-task status table with the evidence checked for each completed step."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/hephaestus.toml
+++ b/codex-agents/omo/hephaestus.toml
@@ -1,6 +1,6 @@
 name = "hephaestus"
 description = "Use when one agent should finish a task end-to-end without check-ins or delegation — explores, plans, implements, and verifies on its own; returns the implemented changes plus test and verification output."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/omo/metis.toml
+++ b/codex-agents/omo/metis.toml
@@ -1,6 +1,6 @@
 name = "metis"
 description = "Use before planning starts when a request may be ambiguous, over-scoped, or misread; returns an intent classification, the ambiguities found, and the clarifying questions to ask first."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/momus.toml
+++ b/codex-agents/omo/momus.toml
@@ -1,6 +1,6 @@
 name = "momus"
 description = "Use when a finished work plan needs an executability check before anyone starts building; returns blocking issues only, each with the plan location and a concrete fix. Read-only."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/oracle.toml
+++ b/codex-agents/omo/oracle.toml
@@ -1,6 +1,6 @@
 name = "oracle"
 description = "Use when an architecture decision or a stuck bug needs a deep read-only second opinion; returns a reasoned recommendation with tradeoffs, risks, and the next concrete step. Changes nothing."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/prometheus.toml
+++ b/codex-agents/omo/prometheus.toml
@@ -1,6 +1,6 @@
 name = "prometheus"
 description = "Use when a request needs a plan before any code is written — runs a structured interview and researches the codebase; returns a markdown work plan with phases, ordered steps, and acceptance criteria."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/sisyphus.toml
+++ b/codex-agents/omo/sisyphus.toml
@@ -1,6 +1,6 @@
 name = "sisyphus"
 description = "Use when a multi-step request has no plan yet and needs relentless end-to-end orchestration — classifies intent, delegates to specialists, and re-delegates until every result verifies; returns a completion report with per-task verification evidence. Never writes code."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/scripts/md-to-toml.sh
+++ b/scripts/md-to-toml.sh
@@ -24,23 +24,38 @@ SKIP_FILES=("agent-teams-reference.md")
 # staging round-trip cleanly: it injects $MODEL_TIER_HIGH (etc.) directly
 # into the .md frontmatter when a file has no model: field, and that value
 # must map back to its own tier here instead of falling through to default.
+# Three input shapes reach this function and all three must be handled:
+#   1. Pinned Claude IDs   — this repo's own agents (claude-opus-5, ...)
+#   2. Bare tier aliases   — upstream oh-my-claudecode writes `model: opus`
+#   3. Codex-native tiers  — install.sh's omx staging injects $MODEL_TIER_*
+#
+# Shapes 1 and 2 were previously absent for the current Claude generation, so
+# `claude-opus-5`, `claude-fable-5`, and the bare `opus` / `haiku` aliases all
+# fell through to default and were silently rewritten to MEDIUM — an opus-class
+# agent demoted, a haiku-class agent promoted. Keep every generation listed:
+# an unrecognised model here is a silent tier change, never an error.
 map_model() {
   local m="$1"
   case "$m" in
-    claude-opus-4-5|claude-opus-4-6|"$MODEL_TIER_HIGH")
+    # Top tier: Fable/Opus class and the bare `opus` alias.
+    claude-fable-5|claude-mythos-5|claude-opus-5|claude-opus-4-8|claude-opus-4-7|claude-opus-4-6|claude-opus-4-5|opus|"$MODEL_TIER_HIGH")
       echo "model = \"$MODEL_TIER_HIGH\""
       echo "model_reasoning_effort = \"$MODEL_TIER_HIGH_EFFORT\""
       ;;
-    claude-sonnet-4-6|claude-sonnet-4-5|"$MODEL_TIER_MEDIUM")
+    # Workhorse tier: Sonnet class and the bare `sonnet` alias.
+    claude-sonnet-5|claude-sonnet-4-6|claude-sonnet-4-5|sonnet|"$MODEL_TIER_MEDIUM")
       echo "model = \"$MODEL_TIER_MEDIUM\""
       echo "model_reasoning_effort = \"$MODEL_TIER_MEDIUM_EFFORT\""
       ;;
-    claude-haiku-4-5|"$MODEL_TIER_LOW")
+    # Cheap tier: Haiku class and the bare `haiku` alias.
+    claude-haiku-4-5|haiku|"$MODEL_TIER_LOW")
       echo "model = \"$MODEL_TIER_LOW\""
       echo "model_reasoning_effort = \"$MODEL_TIER_LOW_EFFORT\""
       ;;
     *)
-      # default / unknown
+      # Unknown model: fall back to the workhorse tier, but say so on stderr.
+      # Silence here is how the demotions above went unnoticed.
+      echo "[md-to-toml] warning: unrecognised model '$m'; defaulting to $MODEL_TIER_MEDIUM" >&2
       echo "model = \"$MODEL_TIER_MEDIUM\""
       echo "model_reasoning_effort = \"$MODEL_TIER_MEDIUM_EFFORT\""
       ;;


### PR DESCRIPTION
Audited every agent's model setting across both repos. `my-claude` is clean — all 13 agents already sit on the current generation (`claude-fable-5` ×1, `claude-opus-5` ×8, `claude-sonnet-5` ×4). Two defects here.

## 1. Eight agents pinned a model that does not exist

`boss` plus the seven `omo` agents (atlas, hephaestus, metis, momus, oracle, prometheus, sisyphus) pinned the bare `gpt-5.6` — not a slug the API serves:

```
400 invalid_request_error: The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account.
```

They only worked because `normalize_agent_models()` rewrote them at install time. **The repo was shipping an invalid value and relying on a runtime repair to hide it** — if normalization ever failed or was skipped, the invalid slug reached the user.

Their Claude counterparts are `claude-fable-5` / `claude-opus-5`, so the intended tier is HIGH. They now pin `gpt-5.6-sol` directly.

| install log | before | after |
|---|---|---|
| `gpt-5.6->gpt-5.6-sol` | **8** rewrites | **0** — nothing left to repair |

## 2. `map_model()` silently demoted agents

It knew no current-generation Claude model and no bare tier alias:

| input | source | old result | new result |
|---|---|---|---|
| `claude-opus-5` | this repo's agents | MEDIUM ❌ **demoted** | HIGH ✅ |
| `claude-fable-5` | `boss` | MEDIUM ❌ **demoted** | HIGH ✅ |
| `opus` | upstream oh-my-claudecode (7 agents) | MEDIUM ❌ **demoted** | HIGH ✅ |
| `haiku` | upstream oh-my-claudecode (2 agents) | MEDIUM ❌ **promoted** | LOW ✅ |
| `sonnet` | upstream (10 agents) | MEDIUM (by luck) | MEDIUM ✅ |

Every one hit the `*)` default and was rewritten to MEDIUM with no error.

**Not currently reachable** for the seven omx-allowlisted agents — `map_role_override()` handles those first — but any agent added outside that allowlist would be silently mis-tiered. Added the Fable/Opus/Sonnet/Haiku generations plus the bare aliases, and **the default branch now warns on stderr**; silence is exactly what let this sit unnoticed.

## Verification (macOS)

- `map_model`: **20/20** inputs map to the intended tier; unknown input warns
- `install.sh` exit 0 — agents unchanged at **sol 12 / terra 20 / luna 2**, **zero invalid slugs**, `auth.json` and `config.toml` checksums untouched
- role tiers intact: `boss`/`architect` xhigh, reviewers/`planner` high, `executor`/`test-engineer`/`debugger` medium
- `codex exec` against an installed agent's model answers

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p