### PR TITLE
feat(ci): reject off-tier agent models, not just stale ones

### DIFF
--- a/scripts/check-model-drift.sh
+++ b/scripts/check-model-drift.sh
@@ -3,7 +3,18 @@
 # check-model-drift.sh — fail if any stale (previous-generation) model ID
 # is still referenced in repo-owned files.
 #
-# Current generation (do NOT flag): gpt-5.6, gpt-5.6-terra, gpt-5.6-luna.
+# Two complementary checks, because a wrong model ID fails in two directions:
+#
+#   1. Stale (blacklist, repo-wide)   — an ID that was real but is now previous
+#      generation. Scanned across all tracked files.
+#   2. Off-tier (allowlist, agents)   — an agent pinning anything other than the
+#      three tiers in model-tiers.sh, including slugs that were never served.
+#
+# Check 2 exists because check 1 cannot catch a nonexistent ID — it only knows
+# what to reject, not what to accept.
+#
+# Current generation (do NOT flag): the MODEL_TIER_* values in
+# scripts/model-tiers.sh, sourced below rather than repeated here.
 #
 # To roll forward on the next model generation, update OLD_MODEL_PATTERN and
 # (if a migration file legitimately references an old ID) EXCLUDE_PATHS.
@@ -33,23 +44,80 @@ EXCLUDE_PATHS="${EXCLUDE_PATHS:-(^|/)upstream/|(^|/)\.git/|(^|/)scripts/model-ti
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
-mapfile -t candidates < <(git ls-files 2>/dev/null | grep -vE "$EXCLUDE_PATHS" || true)
+# `while read` rather than `mapfile`: mapfile is bash 4+, and macOS ships
+# bash 3.2, so mapfile made this script impossible to run locally.
+candidates=""
+while IFS= read -r f; do
+  candidates="$candidates$f
+"
+done < <(git ls-files 2>/dev/null | grep -vE "$EXCLUDE_PATHS" || true)
 
-if [ "${#candidates[@]}" -eq 0 ]; then
+candidate_count=$(printf '%s' "$candidates" | grep -c . || true)
+if [ "$candidate_count" -eq 0 ]; then
   echo "No candidate files to scan."
   exit 0
 fi
 
-hits=$(printf '%s\n' "${candidates[@]}" | tr '\n' '\0' \
+# Tier IDs come from the single source of truth rather than being repeated here.
+. "$repo_root/scripts/model-tiers.sh"
+
+status=0
+
+# ── Check 1: stale IDs (blacklist) ──────────────────────────────────────
+hits=$(printf '%s' "$candidates" | tr '\n' '\0' \
   | xargs -0 grep -nEI "$OLD_MODEL_PATTERN" 2>/dev/null || true)
 
 if [ -n "$hits" ]; then
   echo "FAIL: stale (previous-generation) model IDs found:"
   echo "$hits" | sed 's/^/  /'
   echo ""
-  echo "Update these to the current generation (gpt-5.6 / gpt-5.6-terra / gpt-5.6-luna),"
+  echo "Update these to the current generation ($MODEL_TIER_HIGH / $MODEL_TIER_MEDIUM / $MODEL_TIER_LOW),"
   echo "or add a deliberate exception to EXCLUDE_PATHS in scripts/check-model-drift.sh."
-  exit 1
+  status=1
 fi
 
-echo "OK: no stale model IDs in ${#candidates[@]} scanned files."
+# ── Check 2: off-tier IDs in agent definitions (allowlist) ──────────────
+#
+# Check 1 only catches IDs we already know are old. It cannot catch the
+# opposite failure: a value that is neither old nor real. That gap is not
+# hypothetical — every agent here pinned a bare `gpt-5.6` for weeks, which the
+# API never served (the 5.6 generation ships only suffixed slugs). The stale
+# scan passed the whole time because the value was not *old*, just nonexistent,
+# and installs only worked because normalize_agent_models() repaired it at
+# runtime.
+#
+# Every agent model must be one of the three tiers. A hardcoded slug outside
+# them is a bug even when it happens to be a real model: it bypasses
+# model-tiers.sh, which is what makes rolling the generation forward a
+# three-line edit.
+#
+# Scoped to the structured `model = "..."` field under codex-agents/ — never
+# prose, so a model ID in a doc or comment cannot trip this.
+off_tier=""
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  file="${line%%:*}"
+  rest="${line#*:}"
+  lineno="${rest%%:*}"
+  value=$(printf '%s' "${rest#*:}" | sed 's/^model[[:space:]]*=[[:space:]]*"//; s/".*$//')
+  [ -n "$value" ] || continue
+  case "$value" in
+    "$MODEL_TIER_HIGH"|"$MODEL_TIER_MEDIUM"|"$MODEL_TIER_LOW") ;;
+    *) off_tier="$off_tier  $file:$lineno: $value
+" ;;
+  esac
+done < <(grep -rn '^model[[:space:]]*=' codex-agents/ 2>/dev/null || true)
+
+if [ -n "$off_tier" ]; then
+  echo "FAIL: agent model values outside the defined tiers:"
+  printf '%s' "$off_tier"
+  echo ""
+  echo "Allowed: $MODEL_TIER_HIGH (high) / $MODEL_TIER_MEDIUM (medium) / $MODEL_TIER_LOW (low)"
+  echo "Pin one of those, or change the tier in scripts/model-tiers.sh if the generation moved."
+  status=1
+fi
+
+[ "$status" -eq 0 ] || exit 1
+
+agent_models=$(grep -rc '^model[[:space:]]*=' codex-agents/ 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')
+echo "OK: no stale model IDs in $candidate_count scanned files; $agent_models agent model values all on-tier."


### PR DESCRIPTION
The drift check only knew **what to reject**. A blacklist cannot catch an ID that is neither old nor real — and that gap already cost this repo.

**Every agent here pinned a bare `gpt-5.6` for weeks.** The 5.6 generation ships only suffixed slugs, so the API never served it:

```
400 invalid_request_error: The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account.
```

Every stale scan passed the whole time, because the value was not *old*, just nonexistent. Installs worked only because `normalize_agent_models()` repaired it at runtime — **CI stayed green while the repo shipped an invalid model.**

## What changed

A second check asserting the opposite direction: every `model = "..."` under `codex-agents/` must be one of the three tiers in `model-tiers.sh`.

| failure mode | check 1 (blacklist) | check 2 (allowlist, new) |
|---|---|---|
| `gpt-5.4` — real but previous generation | ✅ caught | — |
| `gpt-5.6` — never served | ❌ **missed** | ✅ caught |
| `gpt-5.5` — real, but off-tier | ❌ missed | ✅ caught |
| model ID in a doc | ✅ passes | ✅ passes (out of scope) |

A hardcoded slug outside the tiers is a bug **even when it is a real model**, because it bypasses `model-tiers.sh` — the file that makes rolling the generation forward a three-line edit. Tier values are **sourced, never duplicated**, so changing `model-tiers.sh` changes what the check enforces.

Scoped to the structured TOML field, never prose — a model ID in a doc or comment cannot trip it. That matters: a gate that cries wolf gets ignored, which is how the upstream sync PRs piled up.

## Also

Replaced `mapfile` with a `while read` loop. `mapfile` is bash 4+ and macOS ships bash 3.2, so **this script could not be run locally at all** before.

## Verification (macOS, bash 3.2)

| case | expected | result |
|---|---|---|
| clean repo | pass | ✅ 94 files scanned, 27 agent models on-tier |
| bare `gpt-5.6` | fail | ✅ **the exact case that slipped through** |
| real-but-off-tier `gpt-5.5` | fail | ✅ |
| same IDs in README prose | pass | ✅ no false positive |
| edit `MODEL_TIER_HIGH` | enforcement follows | ✅ single source of truth confirmed |

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p