### PR TITLE
feat(models): map Claude Fable 5.1 to the top tier

### DIFF
--- a/scripts/md-to-toml.sh
+++ b/scripts/md-to-toml.sh
@@ -30,7 +30,7 @@ SKIP_FILES=("agent-teams-reference.md")
 #   3. Codex-native tiers  — install.sh's omx staging injects $MODEL_TIER_*
 #
 # Shapes 1 and 2 were previously absent for the current Claude generation, so
-# `claude-opus-5`, `claude-fable-5`, and the bare `opus` / `haiku` aliases all
+# `claude-opus-5`, `claude-fable-5-1`, and the bare `opus` / `haiku` aliases all
 # fell through to default and were silently rewritten to MEDIUM — an opus-class
 # agent demoted, a haiku-class agent promoted. Keep every generation listed:
 # an unrecognised model here is a silent tier change, never an error.
@@ -38,7 +38,9 @@ map_model() {
   local m="$1"
   case "$m" in
     # Top tier: Fable/Opus class and the bare `opus` alias.
-    claude-fable-5|claude-mythos-5|claude-opus-5|claude-opus-4-8|claude-opus-4-7|claude-opus-4-6|claude-opus-4-5|opus|"$MODEL_TIER_HIGH")
+    # Superseded IDs stay listed — an agent still pinning claude-fable-5 should
+    # land on the top tier, not fall through to the MEDIUM default.
+    claude-fable-5-1|claude-fable-5|claude-mythos-5|claude-opus-5|claude-opus-4-8|claude-opus-4-7|claude-opus-4-6|claude-opus-4-5|opus|"$MODEL_TIER_HIGH")
       echo "model = \"$MODEL_TIER_HIGH\""
       echo "model_reasoning_effort = \"$MODEL_TIER_HIGH_EFFORT\""
       ;;


### PR DESCRIPTION
Anthropic shipped **Claude Fable 5.1** and moved Claude Fable 5 to the [legacy list](https://platform.claude.com/docs/en/about-claude/models/overview.md). The sibling `my-claude` repo pins Boss to `claude-fable-5-1`, and that value reaches `map_model()` whenever an agent `.md` is converted here.

## Why this matters immediately

Without the entry, `claude-fable-5-1` hits the `*)` default and is rewritten to **MEDIUM** — the top-tier orchestrator silently demoted to the workhorse model.

That is the exact failure `map_model()` was just fixed for in #68, and **a new model generation is precisely when it recurs**. The stderr warning added in that PR would have surfaced it, but only after the demotion had already shipped.

## The ID is `claude-fable-5-1`, hyphenated

Taken from the models overview page, **not inferred** from the marketing name. `claude-fable-5.1` is not valid.

## `claude-fable-5` stays listed

An agent still pinning the superseded ID should land on the top tier, not fall through to MEDIUM. **Dropping old IDs from the map is itself a demotion** — the map exists to tier every input, not only current ones.

## Verification

| group | inputs | result |
|---|---|---|
| HIGH | `claude-fable-5-1`, `claude-fable-5`, `claude-mythos-5`, `claude-opus-5`, `claude-opus-4-8`, `opus`, `gpt-5.6-sol` | ✅ 7/7 → `gpt-5.6-sol` |
| MEDIUM | `claude-sonnet-5`, `sonnet`, `gpt-5.6-terra` | ✅ 3/3 → `gpt-5.6-terra` |
| LOW | `claude-haiku-4-5`, `haiku`, `gpt-5.6-luna` | ✅ 3/3 → `gpt-5.6-luna` |
| unknown | `claude-fable-9` | ✅ → MEDIUM **with stderr warning** |

Drift check passes: 94 files scanned, 27 agent models on-tier.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p