### PR TITLE
feat(boss): structured final report spec at end of turn

### DIFF
--- a/codex-agents/core/boss.toml
+++ b/codex-agents/core/boss.toml
@@ -123,4 +123,25 @@ MCP Tool Awareness:
 - Library documentation → context7 tools (if available)
 - Web search → exa tools (if available)
 - Code search → grep_app tools (if available)
+
+FINAL REPORT (end of every working turn):
+This runs at the VERY END of your reasoning — after all delegation, verification, and side work is complete. Never emit it mid-task as a progress update.
+
+When it fires: any turn where state changed — files edited or created, commits/PRs/merges made, configuration altered, or verification executed. Pure Q&A, explanations, and turns where nothing changed end normally without it.
+
+Format: close your reply with a concise final report assembled from these tables. Include ONLY the tables whose situation occurred; never emit an empty table or invent rows. Precede the tables with at most 2-3 sentences of summary.
+
+| Situation | Table | Columns |
+|-----------|-------|---------|
+| Files/settings changed | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
+| Multiple tasks completed | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
+| Verification was run | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
+| Commits/PRs produced | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
+| Anything unresolved | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+
+Rules:
+- Before/After tables are MANDATORY whenever you modified existing files or settings.
+- Every 검증 결과 row needs real evidence (actual command output, exit codes, counts) — never claim a pass you did not observe.
+- 남은 것 is honest accounting: list anything unverified, deferred, or blocked.
+- Match the user's language for the summary prose; table headers may stay as listed.
 """


### PR DESCRIPTION
Mirror of my-claude's FINAL REPORT spec, in `boss.toml`'s `developer_instructions`: five fixed tables (변경 대조 with Before/After, 작업 요약, 검증 결과, 산출물, 남은 것), emitted at the **very end of reasoning**, only when the situation occurred — never an empty table, never as a mid-task progress update. Before/After is mandatory whenever existing files or settings were modified; verification rows need observed evidence.

## Prompt-only here — by design, not omission

my-claude pairs the spec with a Stop hook that blocks once when the report is missing. The codex CLI has no equivalent enforcement point: its hook surface lacks Claude Code's Stop `decision:'block'`, and the wrapper's `session-end.js` runs **after the reply is already delivered** — it cannot send the model back. Enforcement without a working enforcement point would be theater, so this repo ships the spec and leaves the safety net to the sibling repo where it actually works.

## Verified locally

| case | result |
|---|---|
| install.sh | ✅ exit 0 |
| `~/.codex/agents/boss.toml` | ✅ spec present, TOML parses |
| model | ✅ `gpt-5.6-sol` intact |
| `auth.json` | ✅ checksum untouched |

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p