### PR TITLE
docs: replace the invalid bare gpt-5.6 with gpt-5.6-sol everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ developer_instructions = """
 
 | Field | Values | Notes |
 |-------|--------|-------|
-| `model` | `"gpt-5.6"`, `"gpt-5.6-luna"` | Defaults to `gpt-5.6` if omitted |
+| `model` | `"gpt-5.6-sol"`, `"gpt-5.6-luna"` | Defaults to `gpt-5.6-sol` if omitted |
 | `model_reasoning_effort` | `"high"`, `"medium"`, `"low"` | Applies when model supports reasoning |
 | `sandbox_mode` | `"read-only"`, `"workspace-write"` | Use `read-only` for reviewers; `workspace-write` for implementers |
 | `nickname_candidates` | array of strings | Short invocation aliases |
@@ -68,7 +68,7 @@ developer_instructions = """
 
 | Model | Use For |
 |-------|---------|
-| `gpt-5.6` | Standard development work, analysis, orchestration |
+| `gpt-5.6-sol` | Standard development work, analysis, orchestration |
 | `gpt-5.6-luna` | Fast lookups, lightweight agents, frequent invocation |
 
 **Sandbox mode guidance:**

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Boss cascades every request through a priority chain until the best match is fou
 
 | Complexity | Model | Used For |
 |-----------|-------|----------|
-| Deep analysis, architecture | gpt-5.6 (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
+| Deep analysis, architecture | gpt-5.6-sol (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
 | Standard implementation | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
 | Quick lookup, exploration | gpt-5.6-luna (low) | explore, simple advisory |
 
@@ -140,7 +140,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6 high)              │
+│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -183,7 +183,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | Agent | Model | Role | Source |
 |-------|-------|------|--------|
-| Boss | gpt-5.6 high | Dynamic runtime discovery → capability matching → optimal routing. Never writes code. | my-codex |
+| Boss | gpt-5.6-sol high | Dynamic runtime discovery → capability matching → optimal routing. Never writes code. | my-codex |
 
 </details>
 
@@ -192,13 +192,13 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | Agent | Model | Role | Source |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6 high | Intent classification → specialist delegation → verification | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6 high | Autonomous explore → plan → execute → verify | oh-my-openagent |
-| Atlas | gpt-5.6 high | Task decomposition + 4-stage QA verification | oh-my-openagent |
-| Oracle | gpt-5.6 high | Strategic technical consulting (read-only) | oh-my-openagent |
-| Metis | gpt-5.6 high | Intent analysis, ambiguity detection | oh-my-openagent |
-| Momus | gpt-5.6 high | Plan feasibility review | oh-my-openagent |
-| Prometheus | gpt-5.6 high | Interview-based detailed planning | oh-my-openagent |
+| Sisyphus | gpt-5.6-sol high | Intent classification → specialist delegation → verification | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-5.6-sol high | Autonomous explore → plan → execute → verify | oh-my-openagent |
+| Atlas | gpt-5.6-sol high | Task decomposition + 4-stage QA verification | oh-my-openagent |
+| Oracle | gpt-5.6-sol high | Strategic technical consulting (read-only) | oh-my-openagent |
+| Metis | gpt-5.6-sol high | Intent analysis, ambiguity detection | oh-my-openagent |
+| Momus | gpt-5.6-sol high | Plan feasibility review | oh-my-openagent |
+| Prometheus | gpt-5.6-sol high | Interview-based detailed planning | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | Open-source documentation search via MCP | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | Image/screenshot/diagram analysis | oh-my-openagent |
 
@@ -419,7 +419,7 @@ Features built specifically for this project, beyond what upstream sources provi
 | **Boss Meta-Orchestrator** | Dynamic capability discovery → intent classification → 4-priority routing → delegation → verification |
 | **3-Phase Sprint** | Design (interactive) → Execute (autonomous via executor) → Review (interactive vs design doc) |
 | **Agent Tier Priority** | core > omo > omx > opt-in packs. Pack agents are skipped if their name collides with an already-installed agent. Most specialized agent wins. |
-| **Cost Optimization** | gpt-5.6-luna for advisory, gpt-5.6 for implementation — automatic model routing across all 34 installed agents |
+| **Cost Optimization** | gpt-5.6-luna for advisory, gpt-5.6-sol for implementation — automatic model routing across all 34 installed agents |
 | **Briefing Signals** | Wrapper/session logging feeds `.briefing/agents/agent-log.jsonl`, daily summaries, and routing/profile hints |
 | **Smart Packs** | Project-type detection recommends relevant agent packs at session start |
 | **Agent Pack System** | On-demand domain specialist activation via `--profile` and `my-codex-packs` helper |
@@ -550,7 +550,7 @@ A GitHub Actions workflow runs every 3 days, pulling the latest commits from all
 <details>
 <summary><strong>What models does my-codex use?</strong></summary>
 
-Boss and sub-orchestrators (Sisyphus, Atlas, Oracle) use gpt-5.6 with high reasoning effort. Standard workers use gpt-5.6-terra with medium reasoning. Lightweight advisory agents use gpt-5.6-luna.
+Boss and sub-orchestrators (Sisyphus, Atlas, Oracle) use gpt-5.6-sol with high reasoning effort. Standard workers use gpt-5.6-terra with medium reasoning. Lightweight advisory agents use gpt-5.6-luna.
 
 Skills consume the SKILL.md standard as-is with no transformation; only agents are converted to Codex TOML, and the model tier for that conversion is managed from a single file, `scripts/model-tiers.sh`. When Codex ships its next model generation, update only that file — `scripts/md-to-toml.sh` and `install.sh` both source it.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -175,7 +175,7 @@ Codex CLI uses OpenAI reasoning models. Route tasks by complexity:
 
 | Model | Reasoning Effort | Use For |
 |---|---|---|
-| gpt-5.6 (high) | Deep | Architecture, complex analysis, security review |
+| gpt-5.6-sol (high) | Deep | Architecture, complex analysis, security review |
 | gpt-5.6-terra (medium) | Standard | Implementation, code review, debugging |
 | gpt-5.6-luna (low) | Fast | Quick lookups, exploration, trivial changes |
 
@@ -188,7 +188,7 @@ multi_agent = true
 
 Override per-session:
 ```bash
-codex --model gpt-5.6 --reasoning-effort high "Design the auth system"
+codex --model gpt-5.6-sol --reasoning-effort high "Design the auth system"
 ```
 
 ---
@@ -223,7 +223,7 @@ to dependent tasks.
 
 ```
 You are boss. The goal is to add OAuth2 support.
-1. Use architect to design the approach (spawn with model=gpt-5.6, effort=high)
+1. Use architect to design the approach (spawn with model=gpt-5.6-sol, effort=high)
 2. Use planner to create task breakdown
 3. Spawn executor agents for each implementation task (parallel where safe)
 4. Use code-reviewer to review all changes

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -104,7 +104,7 @@ Boss leitet jede Anfrage durch eine Prioritätskette, bis die beste Übereinstim
 
 | Komplexität | Modell | Verwendet für |
 |-------------|--------|---------------|
-| Tiefgehende Analyse, Architektur | gpt-5.6 (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
+| Tiefgehende Analyse, Architektur | gpt-5.6-sol (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
 | Standardimplementierung | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
 | Schnelle Suche, Erkundung | gpt-5.6-luna (low) | explore, einfache Beratung |
 
@@ -131,7 +131,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6 high)              │
+│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -174,7 +174,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | Agent | Modell | Rolle | Quelle |
 |-------|--------|-------|--------|
-| Boss | gpt-5.6 high | Dynamische Laufzeitentdeckung → Fähigkeitsabgleich → optimales Routing. Schreibt niemals Code. | my-codex |
+| Boss | gpt-5.6-sol high | Dynamische Laufzeitentdeckung → Fähigkeitsabgleich → optimales Routing. Schreibt niemals Code. | my-codex |
 
 </details>
 
@@ -183,13 +183,13 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | Agent | Modell | Rolle | Quelle |
 |-------|--------|-------|--------|
-| Sisyphus | gpt-5.6 high | Absichtsklassifizierung → Spezialistendelegation → Verifikation | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6 high | Autonom erkunden → planen → ausführen → verifizieren | oh-my-openagent |
-| Atlas | gpt-5.6 high | Aufgabenzerlegung + 4-stufige QA-Verifikation | oh-my-openagent |
-| Oracle | gpt-5.6 high | Strategische technische Beratung (nur lesend) | oh-my-openagent |
-| Metis | gpt-5.6 high | Absichtsanalyse, Mehrdeutigkeitserkennung | oh-my-openagent |
-| Momus | gpt-5.6 high | Überprüfung der Planumsetzbarkeit | oh-my-openagent |
-| Prometheus | gpt-5.6 high | Interviewbasierte detaillierte Planung | oh-my-openagent |
+| Sisyphus | gpt-5.6-sol high | Absichtsklassifizierung → Spezialistendelegation → Verifikation | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-5.6-sol high | Autonom erkunden → planen → ausführen → verifizieren | oh-my-openagent |
+| Atlas | gpt-5.6-sol high | Aufgabenzerlegung + 4-stufige QA-Verifikation | oh-my-openagent |
+| Oracle | gpt-5.6-sol high | Strategische technische Beratung (nur lesend) | oh-my-openagent |
+| Metis | gpt-5.6-sol high | Absichtsanalyse, Mehrdeutigkeitserkennung | oh-my-openagent |
+| Momus | gpt-5.6-sol high | Überprüfung der Planumsetzbarkeit | oh-my-openagent |
+| Prometheus | gpt-5.6-sol high | Interviewbasierte detaillierte Planung | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | Open-Source-Dokumentationssuche über MCP | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | Bild-/Screenshot-/Diagrammanalyse | oh-my-openagent |
 
@@ -391,7 +391,7 @@ Funktionen, die speziell für dieses Projekt entwickelt wurden und über das hin
 | **Boss Meta-Orchestrator** | Dynamische Fähigkeitsentdeckung → Absichtsklassifizierung → 4-Prioritäten-Routing → Delegation → Verifikation |
 | **3-Phasen-Sprint** | Design (interaktiv) → Ausführung (autonom über executor) → Review (interaktiv vs. Design-Dokument) |
 | **Agenten-Tier-Priorität** | core > omo > omx > Opt-in-Packs. Pack-Agenten mit Namenskollision zu einem bereits installierten Agenten werden übersprungen. Der speziellste Agent gewinnt. |
-| **Kostenoptimierung** | gpt-5.6-luna für Beratung, gpt-5.6 für Implementierung — automatisches Modell-Routing über alle 34 installierten Agenten |
+| **Kostenoptimierung** | gpt-5.6-luna für Beratung, gpt-5.6-sol für Implementierung — automatisches Modell-Routing über alle 34 installierten Agenten |
 | **Agenten-Telemetrie** | PostToolUse-Hook protokolliert Agentennutzung in `agent-usage.jsonl` |
 | **Smart Packs** | Projekttypenerkennung empfiehlt relevante Agenten-Packs beim Sitzungsstart |
 | **Agenten-Pack-System** | On-demand-Domänenspezialisten-Aktivierung über `--profile` und `my-codex-packs`-Hilfsprogramm |
@@ -522,7 +522,7 @@ Ein GitHub Actions-Workflow läuft alle 3 Tage, zieht die neuesten Commits aus a
 <details>
 <summary><strong>Welche Modelle verwendet my-codex?</strong></summary>
 
-Boss und Sub-Orchestratoren (Sisyphus, Atlas, Oracle) verwenden gpt-5.6 mit hohem Reasoning-Aufwand. Standard-Worker verwenden gpt-5.6-terra mit mittlerem Reasoning. Leichtgewichtige Beratungsagenten verwenden gpt-5.6-luna.
+Boss und Sub-Orchestratoren (Sisyphus, Atlas, Oracle) verwenden gpt-5.6-sol mit hohem Reasoning-Aufwand. Standard-Worker verwenden gpt-5.6-terra mit mittlerem Reasoning. Leichtgewichtige Beratungsagenten verwenden gpt-5.6-luna.
 
 </details>
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -108,7 +108,7 @@ Boss cascade chaque requête dans une chaîne de priorités jusqu'à trouver la 
 
 | Complexité | Modèle | Utilisé pour |
 |-----------|-------|----------|
-| Analyse approfondie, architecture | gpt-5.6 (raisonnement élevé) | Boss, Oracle, Sisyphus, Atlas |
+| Analyse approfondie, architecture | gpt-5.6-sol (raisonnement élevé) | Boss, Oracle, Sisyphus, Atlas |
 | Implémentation standard | gpt-5.6-terra (moyen) | executor, debugger, security-reviewer |
 | Recherche rapide, exploration | gpt-5.6-luna (faible) | explore, conseil simple |
 
@@ -138,7 +138,7 @@ terminée"                                       User : approuver /
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Méta-Orchestrateur (gpt-5.6 high)             │
+│  Boss · Méta-Orchestrateur (gpt-5.6-sol high)             │
 │  Découverte → Classification → Correspondance →       │
 │  Délégation                                           │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
@@ -184,7 +184,7 @@ terminée"                                       User : approuver /
 
 | Agent | Modèle | Rôle | Source |
 |-------|-------|------|--------|
-| Boss | gpt-5.6 high | Découverte dynamique à l'exécution → correspondance de capacités → routage optimal. N'écrit jamais de code. | my-codex |
+| Boss | gpt-5.6-sol high | Découverte dynamique à l'exécution → correspondance de capacités → routage optimal. N'écrit jamais de code. | my-codex |
 
 </details>
 
@@ -193,13 +193,13 @@ terminée"                                       User : approuver /
 
 | Agent | Modèle | Rôle | Source |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6 high | Classification d'intention → délégation aux spécialistes → vérification | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6 high | Exploration autonome → planification → exécution → vérification | oh-my-openagent |
-| Atlas | gpt-5.6 high | Décomposition de tâches + vérification QA en 4 étapes | oh-my-openagent |
-| Oracle | gpt-5.6 high | Conseil technique stratégique (lecture seule) | oh-my-openagent |
-| Metis | gpt-5.6 high | Analyse d'intention, détection d'ambiguïté | oh-my-openagent |
-| Momus | gpt-5.6 high | Révision de faisabilité des plans | oh-my-openagent |
-| Prometheus | gpt-5.6 high | Planification détaillée par entretien | oh-my-openagent |
+| Sisyphus | gpt-5.6-sol high | Classification d'intention → délégation aux spécialistes → vérification | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-5.6-sol high | Exploration autonome → planification → exécution → vérification | oh-my-openagent |
+| Atlas | gpt-5.6-sol high | Décomposition de tâches + vérification QA en 4 étapes | oh-my-openagent |
+| Oracle | gpt-5.6-sol high | Conseil technique stratégique (lecture seule) | oh-my-openagent |
+| Metis | gpt-5.6-sol high | Analyse d'intention, détection d'ambiguïté | oh-my-openagent |
+| Momus | gpt-5.6-sol high | Révision de faisabilité des plans | oh-my-openagent |
+| Prometheus | gpt-5.6-sol high | Planification détaillée par entretien | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | Recherche de documentation open source via MCP | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | Analyse d'images, captures d'écran et diagrammes | oh-my-openagent |
 
@@ -401,7 +401,7 @@ Fonctionnalités construites spécifiquement pour ce projet, au-delà de ce que 
 | **Boss Méta-Orchestrateur** | Découverte dynamique des capacités → classification d'intention → routage à 4 priorités → délégation → vérification |
 | **Sprint 3 phases** | Conception (interactive) → Exécution (autonome via executor) → Révision (interactive vs doc de conception) |
 | **Priorité par niveau d'agent** | core > omo > omx > packs optionnels. Un agent de pack dont le nom entre en collision avec un agent déjà installé est ignoré. L'agent le plus spécialisé l'emporte. |
-| **Optimisation des coûts** | gpt-5.6-luna pour le conseil, gpt-5.6 pour l'implémentation — routage de modèle automatique sur les 34 agents installés |
+| **Optimisation des coûts** | gpt-5.6-luna pour le conseil, gpt-5.6-sol pour l'implémentation — routage de modèle automatique sur les 34 agents installés |
 | **Télémétrie des agents** | Le hook PostToolUse enregistre l'utilisation des agents dans `agent-usage.jsonl` |
 | **Smart Packs** | La détection du type de projet recommande les packs d'agents pertinents au démarrage de session |
 | **Système de packs d'agents** | Activation de spécialistes de domaine à la demande via `--profile` et l'aide `my-codex-packs` |
@@ -532,7 +532,7 @@ Un workflow GitHub Actions s'exécute tous les 3 jours, récupérant les dernier
 <details>
 <summary><strong>Quels modèles utilise my-codex ?</strong></summary>
 
-Boss et les sous-orchestrateurs (Sisyphus, Atlas, Oracle) utilisent gpt-5.6 avec un niveau de raisonnement élevé. Les agents de travail standard utilisent gpt-5.6-terra avec un raisonnement moyen. Les agents de conseil légers utilisent gpt-5.6-luna.
+Boss et les sous-orchestrateurs (Sisyphus, Atlas, Oracle) utilisent gpt-5.6-sol avec un niveau de raisonnement élevé. Les agents de travail standard utilisent gpt-5.6-terra avec un raisonnement moyen. Les agents de conseil légers utilisent gpt-5.6-luna.
 
 </details>
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -104,7 +104,7 @@ Boss はすべてのリクエストを優先チェーンにカスケードし、
 
 | 複雑度 | モデル | 使用場面 |
 |-----------|-------|----------|
-| 深い分析、アーキテクチャ | gpt-5.6 (high reasoning) | Boss、Oracle、Sisyphus、Atlas |
+| 深い分析、アーキテクチャ | gpt-5.6-sol (high reasoning) | Boss、Oracle、Sisyphus、Atlas |
 | 標準的な実装 | gpt-5.6-terra (medium) | executor、debugger、security-reviewer |
 | 簡単な検索、調査 | gpt-5.6-luna (low) | explore、簡易アドバイザリー |
 
@@ -131,7 +131,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6 high)              │
+│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -174,7 +174,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | エージェント | モデル | 役割 | ソース |
 |-------|-------|------|--------|
-| Boss | gpt-5.6 high | ダイナミックランタイム検出 → ケイパビリティマッチング → 最適ルーティング。コードは書かない。 | my-codex |
+| Boss | gpt-5.6-sol high | ダイナミックランタイム検出 → ケイパビリティマッチング → 最適ルーティング。コードは書かない。 | my-codex |
 
 </details>
 
@@ -183,13 +183,13 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | エージェント | モデル | 役割 | ソース |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6 high | インテント分類 → スペシャリスト委任 → 検証 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6 high | 自律的な調査 → 計画 → 実行 → 検証 | oh-my-openagent |
-| Atlas | gpt-5.6 high | タスク分解 + 4 ステージ QA 検証 | oh-my-openagent |
-| Oracle | gpt-5.6 high | 戦略的技術コンサルティング（読み取り専用） | oh-my-openagent |
-| Metis | gpt-5.6 high | インテント分析、曖昧さ検出 | oh-my-openagent |
-| Momus | gpt-5.6 high | 計画実現可能性レビュー | oh-my-openagent |
-| Prometheus | gpt-5.6 high | インタビューベースの詳細計画立案 | oh-my-openagent |
+| Sisyphus | gpt-5.6-sol high | インテント分類 → スペシャリスト委任 → 検証 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-5.6-sol high | 自律的な調査 → 計画 → 実行 → 検証 | oh-my-openagent |
+| Atlas | gpt-5.6-sol high | タスク分解 + 4 ステージ QA 検証 | oh-my-openagent |
+| Oracle | gpt-5.6-sol high | 戦略的技術コンサルティング（読み取り専用） | oh-my-openagent |
+| Metis | gpt-5.6-sol high | インテント分析、曖昧さ検出 | oh-my-openagent |
+| Momus | gpt-5.6-sol high | 計画実現可能性レビュー | oh-my-openagent |
+| Prometheus | gpt-5.6-sol high | インタビューベースの詳細計画立案 | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | MCP 経由のオープンソースドキュメント検索 | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | 画像・スクリーンショット・図の分析 | oh-my-openagent |
 
@@ -391,7 +391,7 @@ my-codex は **4 つのアップストリームサブモジュール**に加え�
 | **Boss メタオーケストレーター** | ダイナミックケイパビリティ検出 → インテント分類 → 4 優先ルーティング → 委任 → 検証 |
 | **3 フェーズスプリント** | 設計（インタラクティブ）→ 実行（executor による自律）→ レビュー（設計書との比較インタラクティブ） |
 | **エージェント層優先度** | core > omo > omx > オプトインパックの順で重複排除。既存エージェントと名前が衝突するパックエージェントはスキップ。最も特化したエージェントが優先。 |
-| **コスト最適化** | アドバイザリーには gpt-5.6-luna、実装には gpt-5.6 — インストール済み 34 エージェント全体への自動モデルルーティング |
+| **コスト最適化** | アドバイザリーには gpt-5.6-luna、実装には gpt-5.6-sol — インストール済み 34 エージェント全体への自動モデルルーティング |
 | **エージェントテレメトリー** | PostToolUse フックがエージェント使用状況を `agent-usage.jsonl` に記録 |
 | **スマートパック** | プロジェクトタイプ検出がセッション開始時に関連エージェントパックを推奨 |
 | **エージェントパックシステム** | `--profile` と `my-codex-packs` ヘルパーによるオンデマンドのドメインスペシャリスト有効化 |
@@ -522,7 +522,7 @@ GitHub Actions ワークフローが 3 日ごとに実行され、4 つのアッ
 <details>
 <summary><strong>my-codex が使用するモデルは何ですか？</strong></summary>
 
-Boss とサブオーケストレーター（Sisyphus、Atlas、Oracle）は高い推論努力で gpt-5.6 を使用します。標準ワーカーは中程度の推論で gpt-5.6-terra を使用します。軽量アドバイザリーエージェントは gpt-5.6-luna を使用します。
+Boss とサブオーケストレーター（Sisyphus、Atlas、Oracle）は高い推論努力で gpt-5.6-sol を使用します。標準ワーカーは中程度の推論で gpt-5.6-terra を使用します。軽量アドバイザリーエージェントは gpt-5.6-luna を使用します。
 
 </details>
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -104,7 +104,7 @@ Boss는 가장 적합한 매칭을 찾을 때까지 모든 요청을 우선순�
 
 | 복잡도 | 모델 | 사용 대상 |
 |-----------|-------|----------|
-| 심층 분석, 아키텍처 | gpt-5.6 (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
+| 심층 분석, 아키텍처 | gpt-5.6-sol (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
 | 표준 구현 | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
 | 빠른 조회, 탐색 | gpt-5.6-luna (low) | explore, 간단한 자문 |
 
@@ -131,7 +131,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6 high)              │
+│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -174,7 +174,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | 에이전트 | 모델 | 역할 | 출처 |
 |-------|-------|------|--------|
-| Boss | gpt-5.6 high | 동적 런타임 탐색 → 역량 매칭 → 최적 라우팅. 코드를 직접 작성하지 않습니다. | my-codex |
+| Boss | gpt-5.6-sol high | 동적 런타임 탐색 → 역량 매칭 → 최적 라우팅. 코드를 직접 작성하지 않습니다. | my-codex |
 
 </details>
 
@@ -183,13 +183,13 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | 에이전트 | 모델 | 역할 | 출처 |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6 high | 의도 분류 → 전문가 위임 → 검증 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6 high | 자율적 탐색 → 계획 → 실행 → 검증 | oh-my-openagent |
-| Atlas | gpt-5.6 high | 작업 분해 + 4단계 QA 검증 | oh-my-openagent |
-| Oracle | gpt-5.6 high | 전략적 기술 컨설팅 (읽기 전용) | oh-my-openagent |
-| Metis | gpt-5.6 high | 의도 분석, 모호성 탐지 | oh-my-openagent |
-| Momus | gpt-5.6 high | 계획 실현 가능성 검토 | oh-my-openagent |
-| Prometheus | gpt-5.6 high | 인터뷰 기반 세부 계획 수립 | oh-my-openagent |
+| Sisyphus | gpt-5.6-sol high | 의도 분류 → 전문가 위임 → 검증 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-5.6-sol high | 자율적 탐색 → 계획 → 실행 → 검증 | oh-my-openagent |
+| Atlas | gpt-5.6-sol high | 작업 분해 + 4단계 QA 검증 | oh-my-openagent |
+| Oracle | gpt-5.6-sol high | 전략적 기술 컨설팅 (읽기 전용) | oh-my-openagent |
+| Metis | gpt-5.6-sol high | 의도 분석, 모호성 탐지 | oh-my-openagent |
+| Momus | gpt-5.6-sol high | 계획 실현 가능성 검토 | oh-my-openagent |
+| Prometheus | gpt-5.6-sol high | 인터뷰 기반 세부 계획 수립 | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | MCP를 통한 오픈소스 문서 검색 | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | 이미지/스크린샷/다이어그램 분석 | oh-my-openagent |
 
@@ -391,7 +391,7 @@ my-codex는 **4개의 업스트림 서브모듈**과 벤더링된 스냅샷 1개
 | **Boss 메타 오케스트레이터** | 동적 역량 탐색 → 의도 분류 → 4단계 우선순위 라우팅 → 위임 → 검증 |
 | **3단계 스프린트** | 설계 (대화형) → 실행 (executor를 통한 자율) → 리뷰 (설계 문서와 대화형 비교) |
 | **에이전트 티어 우선순위** | core > omo > omx > 옵트인 팩 순으로 중복 제거. 이미 설치된 에이전트와 이름이 겹치는 팩 에이전트는 건너뜁니다. 가장 특화된 에이전트가 선택됩니다. |
-| **비용 최적화** | 자문에는 gpt-5.6-luna, 구현에는 gpt-5.6 — 설치된 34개 에이전트 전체에 대한 자동 모델 라우팅 |
+| **비용 최적화** | 자문에는 gpt-5.6-luna, 구현에는 gpt-5.6-sol — 설치된 34개 에이전트 전체에 대한 자동 모델 라우팅 |
 | **에이전트 텔레메트리** | PostToolUse 훅이 에이전트 사용량을 `agent-usage.jsonl`에 기록 |
 | **Smart Packs** | 프로젝트 유형 감지로 세션 시작 시 관련 에이전트 팩 추천 |
 | **에이전트 팩 시스템** | `--profile` 및 `my-codex-packs` 헬퍼를 통한 온디맨드 도메인 전문가 활성화 |
@@ -522,7 +522,7 @@ GitHub Actions 워크플로가 3일마다 실행되어 4개 업스트림 서브�
 <details>
 <summary><strong>my-codex는 어떤 모델을 사용하나요?</strong></summary>
 
-Boss와 서브 오케스트레이터(Sisyphus, Atlas, Oracle)는 high reasoning effort의 gpt-5.6를 사용합니다. 표준 작업자는 medium reasoning의 gpt-5.6-terra를 사용합니다. 경량 자문 에이전트는 gpt-5.6-luna를 사용합니다.
+Boss와 서브 오케스트레이터(Sisyphus, Atlas, Oracle)는 high reasoning effort의 gpt-5.6-sol를 사용합니다. 표준 작업자는 medium reasoning의 gpt-5.6-terra를 사용합니다. 경량 자문 에이전트는 gpt-5.6-luna를 사용합니다.
 
 </details>
 

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -104,7 +104,7 @@ Boss 对每个请求按优先级链逐级匹配，直到找到最佳方案：
 
 | 复杂度 | 模型 | 用途 |
 |-----------|-------|----------|
-| 深度分析、架构 | gpt-5.6（high reasoning） | Boss、Oracle、Sisyphus、Atlas |
+| 深度分析、架构 | gpt-5.6-sol（high reasoning） | Boss、Oracle、Sisyphus、Atlas |
 | 标准实现 | gpt-5.6-terra（medium） | executor、debugger、security-reviewer |
 | 快速查询、探索 | gpt-5.6-luna（low） | explore、简单咨询 |
 
@@ -131,7 +131,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6 high)              │
+│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -174,7 +174,7 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | Agent | 模型 | 角色 | 来源 |
 |-------|-------|------|--------|
-| Boss | gpt-5.6 high | 动态运行时发现 → 能力匹配 → 最优路由。从不编写代码。 | my-codex |
+| Boss | gpt-5.6-sol high | 动态运行时发现 → 能力匹配 → 最优路由。从不编写代码。 | my-codex |
 
 </details>
 
@@ -183,13 +183,13 @@ Confirm "design done"   Architect verification  User: approve / improve
 
 | Agent | 模型 | 角色 | 来源 |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6 high | 意图分类 → 专家委派 → 验证 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6 high | 自主探索 → 规划 → 执行 → 验证 | oh-my-openagent |
-| Atlas | gpt-5.6 high | 任务分解 + 四阶段 QA 验证 | oh-my-openagent |
-| Oracle | gpt-5.6 high | 战略技术咨询（只读） | oh-my-openagent |
-| Metis | gpt-5.6 high | 意图分析、歧义检测 | oh-my-openagent |
-| Momus | gpt-5.6 high | 计划可行性评审 | oh-my-openagent |
-| Prometheus | gpt-5.6 high | 基于访谈的详细规划 | oh-my-openagent |
+| Sisyphus | gpt-5.6-sol high | 意图分类 → 专家委派 → 验证 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-5.6-sol high | 自主探索 → 规划 → 执行 → 验证 | oh-my-openagent |
+| Atlas | gpt-5.6-sol high | 任务分解 + 四阶段 QA 验证 | oh-my-openagent |
+| Oracle | gpt-5.6-sol high | 战略技术咨询（只读） | oh-my-openagent |
+| Metis | gpt-5.6-sol high | 意图分析、歧义检测 | oh-my-openagent |
+| Momus | gpt-5.6-sol high | 计划可行性评审 | oh-my-openagent |
+| Prometheus | gpt-5.6-sol high | 基于访谈的详细规划 | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | 通过 MCP 搜索开源文档 | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | 图像 / 截图 / 图表分析 | oh-my-openagent |
 
@@ -391,7 +391,7 @@ my-codex 由 **4 个上游子模块**，加上 1 份内置快照与 2 个适配/
 | **Boss 元编排器** | 动态能力发现 → 意图分类 → 4 级优先路由 → 委派 → 验证 |
 | **三阶段冲刺** | 设计（交互式）→ 执行（通过 executor 自主进行）→ 审查（交互式对比设计文档） |
 | **Agent 层级优先级** | core > omo > omx > 可选包 依次去重。与已安装 Agent 同名的包内 Agent 会被跳过。最专业的 Agent 优先。 |
-| **成本优化** | 咨询用 gpt-5.6-luna，实现用 gpt-5.6——覆盖全部 34 个已安装 Agent 的自动模型路由 |
+| **成本优化** | 咨询用 gpt-5.6-luna，实现用 gpt-5.6-sol——覆盖全部 34 个已安装 Agent 的自动模型路由 |
 | **Agent 遥测** | PostToolUse hook 将 Agent 使用情况记录到 `agent-usage.jsonl` |
 | **智能包** | 项目类型检测在会话开始时推荐相关 Agent 包 |
 | **Agent 包系统** | 通过 `--profile` 和 `my-codex-packs` 助手按需激活领域专家 |
@@ -522,7 +522,7 @@ GitHub Actions 工作流每 3 天运行一次，从 4 个上游子模块拉取�
 <details>
 <summary><strong>my-codex 使用哪些模型？</strong></summary>
 
-Boss 和子编排器（Sisyphus、Atlas、Oracle）使用 gpt-5.6 高推理强度。标准工作者使用 gpt-5.6-terra 中等推理强度。轻量级咨询 Agent 使用 gpt-5.6-luna。
+Boss 和子编排器（Sisyphus、Atlas、Oracle）使用 gpt-5.6-sol 高推理强度。标准工作者使用 gpt-5.6-terra 中等推理强度。轻量级咨询 Agent 使用 gpt-5.6-luna。
 
 </details>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -287,7 +287,7 @@ section{padding:80px 0}
       <h3 style="font-size:1rem;margin-bottom:12px;color:var(--accent)"><span class="lang" data-en="Model Routing" data-ko="모델 라우팅"></span></h3>
       <table class="route-table">
         <tr><th><span class="lang" data-en="Complexity" data-ko="복잡도"></span></th><th><span class="lang" data-en="Model" data-ko="모델"></span></th></tr>
-        <tr><td style="color:var(--primary)"><span class="lang" data-en="Architecture, deep analysis" data-ko="아키텍처, 심층 분석"></span></td><td>gpt-5.6 (high)</td></tr>
+        <tr><td style="color:var(--primary)"><span class="lang" data-en="Architecture, deep analysis" data-ko="아키텍처, 심층 분석"></span></td><td>gpt-5.6-sol (high)</td></tr>
         <tr><td style="color:var(--accent)"><span class="lang" data-en="Standard implementation" data-ko="표준 구현"></span></td><td>gpt-5.6-terra (medium)</td></tr>
         <tr><td style="color:var(--green)"><span class="lang" data-en="Quick lookup, exploration" data-ko="빠른 조회, 탐색"></span></td><td>gpt-5.6-luna (low)</td></tr>
       </table>
@@ -517,7 +517,7 @@ section{padding:80px 0}
     <div class="orig-card"><h4>Boss Meta-Orchestrator</h4><p><span class="lang" data-en="Runtime discovery, 5-phase delegation" data-ko="런타임 탐색, 5단계 위임"></span></p></div>
     <div class="orig-card"><h4>MD→TOML Pipeline</h4><p><span class="lang" data-en="Automated format conversion from upstream" data-ko="업스트림에서 자동 형식 변환"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Agent Tier Priority" data-ko="에이전트 계층 우선순위"></span></h4><p><span class="lang" data-en="Core > OMO > OMX > opt-in packs dedup resolution" data-ko="Core > OMO > OMX > 옵트인 팩 중복 해결"></span></p></div>
-    <div class="orig-card"><h4><span class="lang" data-en="Cost-Optimized Routing" data-ko="비용 최적화 라우팅"></span></h4><p><span class="lang" data-en="gpt-5.6 / gpt-5.6-terra / gpt-5.6-luna tier selection" data-ko="gpt-5.6 / gpt-5.6-terra / gpt-5.6-luna 티어 선택"></span></p></div>
+    <div class="orig-card"><h4><span class="lang" data-en="Cost-Optimized Routing" data-ko="비용 최적화 라우팅"></span></h4><p><span class="lang" data-en="gpt-5.6-sol / gpt-5.6-terra / gpt-5.6-luna tier selection" data-ko="gpt-5.6-sol / gpt-5.6-terra / gpt-5.6-luna 티어 선택"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Briefing Vault" data-ko="지식 금고"></span></h4><p><span class="lang" data-en="Obsidian-compatible project memory" data-ko="Obsidian 호환 프로젝트 메모리"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Agent Packs" data-ko="에이전트 팩"></span></h4><p><span class="lang" data-en="Opt-in domain specialist activation profiles" data-ko="옵트인 도메인 전문가 활성화 프로파일"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="3-Day Auto-Sync" data-ko="3일 주기 자동 동기화"></span></h4><p><span class="lang" data-en="Security-gated GitHub Actions upstream curation" data-ko="보안 게이트 GitHub Actions 업스트림 큐레이션"></span></p></div>


### PR DESCRIPTION
The docs still told users to run the HIGH tier as bare `gpt-5.6` — **19 references** across README, SETUP, CONTRIBUTING, the GitHub Pages site, and all five translated READMEs, including copy-pasteable commands:

```bash
codex --model gpt-5.6 --reasoning-effort high "Design the auth system"
```

That slug was never served. Anyone following the docs got:

```
400 invalid_request_error: The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account.
```

The code was fixed in #65/#68 (`MODEL_TIER_HIGH=gpt-5.6-sol`); this brings the prose in line with what ships. `terra`/`luna` references were already correct and are untouched.

Verification: zero bare `gpt-5.6` remain outside `upstream/`; drift check passes (94 files, 27 agent models on-tier).

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p