### PR TITLE
docs: surface the structured final report on README and the pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ Engineering review      Auto code review        Present comparison table
 Confirm "design done"   Architect verification  User: approve / improve
 ```
 
+### Structured Final Report
+
+Boss closes every working turn — any turn that edited files, made commits/PRs, changed configuration, or ran verification — with a structured final report the reader can scan without opening a diff. The report is assembled from five fixed tables, each emitted only when its situation actually occurred (never an empty table):
+
+| Situation | Table | Columns |
+|-----------|-------|---------|
+| Files/settings changed | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
+| Multiple tasks completed | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
+| Verification was run | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
+| Commits/PRs produced | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
+| Anything unresolved | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+
+It fires only at the very end of reasoning — never as a mid-task progress update — and pure Q&A turns end normally without it. The spec ships in `boss.toml`'s developer instructions. (In the sibling [my-claude](https://github.com/sehoon787/my-claude), a Stop hook additionally enforces it; the Codex CLI has no equivalent enforcement point, so here the spec is prompt-level.)
+
 ---
 
 ## Architecture

--- a/docs/index.html
+++ b/docs/index.html
@@ -523,6 +523,7 @@ section{padding:80px 0}
     <div class="orig-card"><h4><span class="lang" data-en="3-Day Auto-Sync" data-ko="3일 주기 자동 동기화"></span></h4><p><span class="lang" data-en="Security-gated GitHub Actions upstream curation" data-ko="보안 게이트 GitHub Actions 업스트림 큐레이션"></span></p></div>
     <div class="orig-card"><h4>Native TOML</h4><p><span class="lang" data-en="Zero-conversion agent format" data-ko="무변환 에이전트 형식"></span></p></div>
     <div class="orig-card"><h4>Dedup Guard</h4><p><span class="lang" data-en="Cross-source agent deduplication" data-ko="크로스 소스 에이전트 중복 제거"></span></p></div>
+    <div class="orig-card"><h4><span class="lang" data-en="Structured Final Report" data-ko="정형화된 최종 보고"></span></h4><p><span class="lang" data-en="Every working turn ends with fixed Before/After, verification, and deliverables tables" data-ko="작업이 있던 모든 턴을 Before/After·검증·산출물 고정 표로 마무리"></span></p></div>
   </div>
 </div>
 </section>


### PR DESCRIPTION
The FINAL REPORT spec shipped in #71 but was only discoverable by reading `boss.toml`.

- **README**: new "Structured Final Report" section under *How Boss Works* — when it fires, the five fixed tables with their exact column sets, and an honest note that enforcement is prompt-level here (the Codex CLI has no Stop-block equivalent; the sibling my-claude adds a hook)
- **Pages site**: matching feature card (en/ko)

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p