### PR TITLE
feat: add codeburn as a companion CLI for Codex cost tracking

### DIFF
--- a/AI-INSTALL.md
+++ b/AI-INSTALL.md
@@ -206,6 +206,7 @@ rm -rf /tmp/my-codex
 ```bash
 # AST tools for code intelligence
 npm i -g @ast-grep/cli@0.42.0
+npm i -g codeburn@0.9.23
 ```
 
 ## Step 3: Customize active agent packs (optional)

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ The Stop hook checks whether `/boss-briefing` has run today. If not, it blocks s
 
 ## Upstream Open-Source Sources
 
-my-codex tracks **4 upstream submodules**, plus one vendored snapshot and two adapted/sister projects:
+my-codex tracks **4 upstream submodules**, plus one vendored snapshot, two adapted/sister projects, and one companion CLI:
 
 | # | Source | Method | What It Provides |
 |---|--------|--------|-----------------|
@@ -405,8 +405,9 @@ my-codex tracks **4 upstream submodules**, plus one vendored snapshot and two ad
 | 5 | <img src="https://github.com/VoltAgent.png?size=32" width="20" height="20" align="center"/> **[awesome-codex-subagents](https://github.com/VoltAgent/awesome-codex-subagents)** — VoltAgent | vendored (MIT) | 17 AI/LLM agents snapshotted into `codex-agents/packs/` as 2 opt-in packs (data-ai 13, llmops 4). Submodule removed 2026-07-27. |
 | 6 | <img src="https://github.com/code-yeongyu.png?size=32" width="20" height="20" align="center"/> **[oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)** — code-yeongyu | adapted | 9 OMO agents (Sisyphus, Atlas, Oracle, etc.). Adapted to Codex-native TOML format and maintained in-repo. |
 | 7 | <img src="https://github.com/sehoon787.png?size=32" width="20" height="20" align="center"/> **[my-claude](https://github.com/sehoon787/my-claude)** — sehoon787 | sister project | Same Boss orchestration in native Claude `.md` agent format. Skills, rules, and briefing vault shared across both projects. |
+| 8 | <img src="https://github.com/getagentseal.png?size=32" width="20" height="20" align="center"/> **[codeburn](https://github.com/getagentseal/codeburn)** — getagentseal | npm CLI (MIT) | Local-first token/cost tracker. Parses `~/.codex/sessions` read-only — no proxy, no upload. Installed by `install.sh` (pinned `codeburn@0.9.23`), registered in `upstream/SOURCES.json` as `method: npm-cli`. No hooks on Codex. |
 
-Every submodule is SHA-pinned in `upstream/SOURCES.json` (AI-BOM), which also records the two removed submodules (`agency-agents` — nothing vendored; `awesome-codex-subagents` — 17 agents vendored).
+Every submodule is SHA-pinned in `upstream/SOURCES.json` (AI-BOM) — companion CLIs (ast-grep, codeburn) are version-pinned there too — which also records the two removed submodules (`agency-agents` — nothing vendored; `awesome-codex-subagents` — 17 agents vendored).
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -20,7 +20,7 @@ Give this document to an AI coding agent to reproduce the exact same environment
 
 ## 1. Prerequisites
 
-- **Node.js** v20+
+- **Node.js** v22.13+ (required by codeburn)
 - **npm**
 - **Git**
 - **Codex CLI** — install from [https://github.com/openai/codex](https://github.com/openai/codex) or:

--- a/install.sh
+++ b/install.sh
@@ -1400,6 +1400,12 @@ if command -v ast-grep >/dev/null 2>&1; then
 else
   npm i -g @ast-grep/cli@0.42.0 2>/dev/null || echo "    WARNING: ast-grep install failed"
 fi
+echo "  [6b] codeburn (AI token/cost tracker; reads ~/.codex/sessions read-only)..."
+if command -v codeburn >/dev/null 2>&1; then
+  echo "    codeburn already installed"
+else
+  npm i -g codeburn@0.9.23 2>/dev/null || echo "    WARNING: codeburn install failed"
+fi
 
 LC_ALL=C sort -u "$TMP_MANIFEST" > "$MANIFEST_FILE"
 printf '%s\n' "$INSTALLING_VERSION" > "$VERSION_FILE"
@@ -1421,6 +1427,7 @@ echo "  hooksPath:     $(git config --global --get core.hooksPath 2>/dev/null ||
 echo "  Codex attr:    $(git config --global --get my-codex.codexAttribution 2>/dev/null || echo 'UNSET')"
 echo "  version:       $(cat "$VERSION_FILE" 2>/dev/null || echo 'unknown')"
 echo "  codex:         $(command -v codex >/dev/null 2>&1 && echo "OK ($(codex --version 2>/dev/null))" || echo 'NOT INSTALLED')"
+echo "  codeburn:      $(command -v codeburn >/dev/null 2>&1 && echo 'OK' || echo 'MISSING')"
 echo ""
 echo "=== Install complete ==="
 echo ""

--- a/upstream/SOURCES.json
+++ b/upstream/SOURCES.json
@@ -32,8 +32,15 @@
     "repo": "https://github.com/garrytan/gstack",
     "path": "upstream/gstack",
     "method": "submodule + setup",
-    "supersedes": ["benchmark", "canary-watch", "safety-guard", "browser-qa",
-                   "verification-loop", "security-review", "design-system"],
+    "supersedes": [
+      "benchmark",
+      "canary-watch",
+      "safety-guard",
+      "browser-qa",
+      "verification-loop",
+      "security-review",
+      "design-system"
+    ],
     "pinned_sha": "e76f65a8da31ec14776a965c608222c1aecad656",
     "pinned_date": "2026-08-31",
     "license": "MIT"
@@ -44,6 +51,22 @@
     "method": "submodule",
     "pinned_sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797",
     "pinned_date": "2026-08-31",
+    "license": "MIT"
+  },
+  "codeburn": {
+    "repo": "https://github.com/getagentseal/codeburn",
+    "method": "npm-cli",
+    "package": "codeburn",
+    "pinned_version": "0.9.23",
+    "note": "Local-first AI token/cost tracker; parses ~/.codex/sessions read-only, no proxy, no upload. No hooks on Codex (read-only).",
+    "license": "MIT"
+  },
+  "ast-grep": {
+    "repo": "https://github.com/ast-grep/ast-grep",
+    "method": "npm-cli",
+    "package": "@ast-grep/cli",
+    "pinned_version": "0.42.0",
+    "note": "Structural code search/rewrite CLI used by agents",
     "license": "MIT"
   }
 }


### PR DESCRIPTION
Adds [codeburn](https://github.com/getagentseal/codeburn) (MIT) — parses `~/.codex/sessions` rollouts **read-only** and reports token/cost by model, project, and task. No proxy, no upload. Codex has no HUD, so nothing overlaps.

- Installed as a companion CLI (`codeburn@0.9.23` pinned, step `[6b]` next to ast-grep) — **not a submodule**: nothing to vendor, and it would put a 1,855-commit app under the 3-day upstream scan for nothing
- **No hooks here** — the budget guard targets Claude Code's hook surface, which the Codex CLI lacks
- `upstream/SOURCES.json` (AI-BOM) records codeburn with `method: npm-cli` + pinned version — and closes a pre-existing gap by registering `ast-grep` too. `refresh-sources-pins.js` skips entries without a submodule path, so the sync pipeline is unaffected
- README "Upstream Open-Source Sources" row 8; Node requirement → 22.13+

Drift check passes (94 files, 27 agent models on-tier).

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p