### PR TITLE
docs(i18n): translate Structured Final Report and codeburn into all five READMEs; add codeburn card to the pages site

### DIFF
--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -121,6 +121,20 @@ Engineering review      Auto code review        Present comparison table
 Confirm "design done"   Architect verification  User: approve / improve
 ```
 
+### Strukturierter Abschlussbericht
+
+Boss schließt jeden Arbeits-Turn — jeden Turn, in dem Dateien bearbeitet oder erstellt, Commits/PRs/Merges gemacht, Konfiguration geändert oder Verifikation ausgeführt wurde — mit einem strukturierten Abschlussbericht ab, den man ohne Öffnen eines Diffs überfliegen kann. Der Bericht besteht aus fünf festen Tabellen, die jeweils nur ausgegeben werden, wenn ihre Situation tatsächlich eingetreten ist (niemals eine leere Tabelle):
+
+| Situation | Tabelle | Spalten |
+|-----------|-------|---------|
+| Dateien/Einstellungen geändert | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
+| Mehrere Aufgaben abgeschlossen | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
+| Verifikation ausgeführt | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
+| Commits/PRs erzeugt | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
+| Etwas ungelöst | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+
+Er wird nur ganz am Ende des Reasonings ausgelöst — niemals als Fortschrittsmeldung mitten in der Aufgabe — und reine Q&A-Turns enden normal ohne ihn. Die Spezifikation liegt in den developer instructions von `boss.toml`. (Im Schwesterprojekt [my-claude](https://github.com/sehoon787/my-claude) setzt zusätzlich ein Stop-Hook sie durch; die Codex CLI hat keinen vergleichbaren Durchsetzungspunkt, daher ist die Spezifikation hier auf Prompt-Ebene.)
+
 ---
 
 ## Architektur
@@ -352,7 +366,7 @@ BriefingVault v2 integriert drei Wissensmanagement-Methoden:
 
 ## Upstream Open-Source-Quellen
 
-my-codex verfolgt **4 Upstream-Submodule**, dazu einen eingebundenen Snapshot und zwei angepasste bzw. Schwesterprojekte:
+my-codex verfolgt **4 Upstream-Submodule**, dazu einen eingebundenen Snapshot zwei angepasste bzw. Schwesterprojekte und eine Companion-CLI:
 
 | # | Quelle | Methode | Was bereitgestellt wird |
 |---|--------|---------|------------------------|
@@ -363,8 +377,9 @@ my-codex verfolgt **4 Upstream-Submodule**, dazu einen eingebundenen Snapshot un
 | 5 | <img src="https://github.com/VoltAgent.png?size=32" width="20" height="20" align="center"/> **[awesome-codex-subagents](https://github.com/VoltAgent/awesome-codex-subagents)** — VoltAgent | eingebunden (MIT) | 17 KI/LLM-Agenten als Snapshot in `codex-agents/packs/`, ausgeliefert als 2 Opt-in-Packs (data-ai 13, llmops 4). Submodul am 2026-07-27 entfernt. |
 | 6 | <img src="https://github.com/code-yeongyu.png?size=32" width="20" height="20" align="center"/> **[oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)** — code-yeongyu | angepasst | 9 OMO-Agenten (Sisyphus, Atlas, Oracle usw.). Für das native Codex-TOML-Format angepasst und im Repository gepflegt. |
 | 7 | <img src="https://github.com/sehoon787.png?size=32" width="20" height="20" align="center"/> **[my-claude](https://github.com/sehoon787/my-claude)** — sehoon787 | Schwesterprojekt | Dieselbe Boss-Orchestrierung im nativen Claude `.md`-Agentenformat. Skills, Regeln und Briefing Vault werden zwischen beiden Projekten geteilt. |
+| 8 | <img src="https://github.com/getagentseal.png?size=32" width="20" height="20" align="center"/> **[codeburn](https://github.com/getagentseal/codeburn)** — getagentseal | npm CLI (MIT) | Local-first Token-/Kosten-Tracker. Liest `~/.codex/sessions` nur lesend — kein Proxy, kein Upload. Von `install.sh` installiert (gepinnt auf `codeburn@0.9.23`), in `upstream/SOURCES.json` als `method: npm-cli` geführt. Keine Hooks unter Codex. |
 
-Jedes Submodul ist in `upstream/SOURCES.json` (AI-BOM) per SHA gepinnt; dort sind auch die beiden entfernten Submodule vermerkt (`agency-agents` — nichts eingebunden; `awesome-codex-subagents` — 17 Agenten eingebunden).
+Jedes Submodul ist in `upstream/SOURCES.json` (AI-BOM) — Companion-CLIs (ast-grep, codeburn) sind dort ebenfalls versionsgepinnt eingetragen — per SHA gepinnt; dort sind auch die beiden entfernten Submodule vermerkt (`agency-agents` — nichts eingebunden; `awesome-codex-subagents` — 17 Agenten eingebunden).
 
 ---
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -128,6 +128,20 @@ terminée"                                       User : approuver /
                                                 améliorer
 ```
 
+### Rapport final structuré
+
+Boss clôt chaque tour de travail — tout tour ayant édité ou créé des fichiers, produit des commits/PR/merges, modifié la configuration ou exécuté une vérification — par un rapport final structuré lisible sans ouvrir de diff. Le rapport est assemblé à partir de cinq tableaux fixes, chacun n'étant émis que si sa situation s'est réellement produite (jamais de tableau vide) :
+
+| Situation | Tableau | Colonnes |
+|-----------|-------|---------|
+| Fichiers/paramètres modifiés | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
+| Plusieurs tâches terminées | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
+| Vérification exécutée | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
+| Commits/PR produits | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
+| Éléments non résolus | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+
+Il ne se déclenche qu'à la toute fin du raisonnement — jamais comme point d'étape en cours de tâche — et les tours de simple Q&R se terminent normalement sans lui. La spécification est livrée dans les developer instructions de `boss.toml`. (Dans le projet frère [my-claude](https://github.com/sehoon787/my-claude), un hook Stop la fait en plus respecter ; la Codex CLI n'a pas de point d'application équivalent, la spécification reste donc au niveau du prompt.)
+
 ---
 
 ## Architecture
@@ -362,7 +376,7 @@ BriefingVault v2 intègre trois méthodologies de gestion des connaissances :
 
 ## Sources open source en amont
 
-my-codex suit **4 sous-modules upstream**, plus un instantané intégré et deux projets adaptés ou sœurs :
+my-codex suit **4 sous-modules upstream**, plus un instantané intégré deux projets adaptés ou sœurs et une CLI compagnon :
 
 | # | Source | Méthode | Ce qu'elle fournit |
 |---|--------|---------|-----------------|
@@ -373,8 +387,9 @@ my-codex suit **4 sous-modules upstream**, plus un instantané intégré et deux
 | 5 | <img src="https://github.com/VoltAgent.png?size=32" width="20" height="20" align="center"/> **[awesome-codex-subagents](https://github.com/VoltAgent/awesome-codex-subagents)** — VoltAgent | intégré (MIT) | 17 agents IA/LLM capturés dans `codex-agents/packs/` sous forme de 2 packs optionnels (data-ai 13, llmops 4). Sous-module supprimé le 2026-07-27. |
 | 6 | <img src="https://github.com/code-yeongyu.png?size=32" width="20" height="20" align="center"/> **[oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)** — code-yeongyu | adapté | 9 agents OMO (Sisyphus, Atlas, Oracle, etc.). Adaptés au format TOML natif Codex et maintenus dans ce dépôt. |
 | 7 | <img src="https://github.com/sehoon787.png?size=32" width="20" height="20" align="center"/> **[my-claude](https://github.com/sehoon787/my-claude)** — sehoon787 | projet sœur | Même orchestration Boss au format natif Claude `.md`. Skills, règles et Briefing Vault partagés entre les deux projets. |
+| 8 | <img src="https://github.com/getagentseal.png?size=32" width="20" height="20" align="center"/> **[codeburn](https://github.com/getagentseal/codeburn)** — getagentseal | CLI npm (MIT) | Suivi local-first des tokens et des coûts. Lit `~/.codex/sessions` en lecture seule — pas de proxy, pas d'upload. Installé par `install.sh` (épinglé `codeburn@0.9.23`), enregistré dans `upstream/SOURCES.json` en `method: npm-cli`. Aucun hook sur Codex. |
 
-Chaque sous-module est épinglé par SHA dans `upstream/SOURCES.json` (AI-BOM), qui consigne aussi les deux sous-modules supprimés (`agency-agents` — rien d'intégré ; `awesome-codex-subagents` — 17 agents intégrés).
+Chaque sous-module est épinglé par SHA dans `upstream/SOURCES.json` (AI-BOM) — les CLI compagnons (ast-grep, codeburn) y sont également épinglées par version —, qui consigne aussi les deux sous-modules supprimés (`agency-agents` — rien d'intégré ; `awesome-codex-subagents` — 17 agents intégrés).
 
 ---
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -121,6 +121,20 @@ Engineering review      Auto code review        Present comparison table
 Confirm "design done"   Architect verification  User: approve / improve
 ```
 
+### 構造化された最終レポート
+
+Boss は作業が発生したすべてのターン — ファイルの編集・作成、コミット/PR/マージ、設定変更、検証の実行があったターン — を、diff を開かなくても読み取れる構造化された最終レポートで締めくくります。レポートは固定された 5 つのテーブルから組み立てられ、各テーブルはその状況が実際に発生した場合にのみ出力されます（空のテーブルは決して出力しません）:
+
+| 状況 | テーブル | 列 |
+|-----------|-------|---------|
+| ファイル/設定の変更 | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
+| 複数タスクの完了 | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
+| 検証を実行 | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
+| コミット/PR を作成 | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
+| 未解決事項あり | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+
+このレポートは推論の最後にのみ発動し — タスク途中の進捗報告としては決して出力されず — 純粋な Q&A のターンはレポートなしで通常どおり終了します。仕様は `boss.toml` の developer instructions に含まれています。（姉妹プロジェクトの [my-claude](https://github.com/sehoon787/my-claude) では Stop フックがさらにこれを強制しますが、Codex CLI には同等の強制ポイントがないため、ここではプロンプトレベルの仕様です。）
+
 ---
 
 ## アーキテクチャ
@@ -352,7 +366,7 @@ BriefingVault v2 は 3 つの知識管理手法を統合しています：
 
 ## アップストリームのオープンソースソース
 
-my-codex は **4 つのアップストリームサブモジュール**に加え、ベンダリング済みスナップショット 1 件と、適応済み/姉妹プロジェクト 2 件で構成されています:
+my-codex は **4 つのアップストリームサブモジュール**に加え、ベンダリング済みスナップショット 1 件と、適応済み/姉妹プロジェクト 2 件で構成されています、companion CLI 1 件で構成されます:
 
 | # | ソース | 方式 | 提供内容 |
 |---|--------|------|-----------------|
@@ -363,8 +377,9 @@ my-codex は **4 つのアップストリームサブモジュール**に加え�
 | 5 | <img src="https://github.com/VoltAgent.png?size=32" width="20" height="20" align="center"/> **[awesome-codex-subagents](https://github.com/VoltAgent/awesome-codex-subagents)** — VoltAgent | ベンダリング (MIT) | AI/LLM エージェント 17 個を `codex-agents/packs/` にスナップショットし、オプトインパック 2 個（data-ai 13、llmops 4）として提供。サブモジュールは 2026-07-27 に削除。 |
 | 6 | <img src="https://github.com/code-yeongyu.png?size=32" width="20" height="20" align="center"/> **[oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)** — code-yeongyu | 適応 | 9 つの OMO エージェント（Sisyphus、Atlas、Oracle など）。Codex ネイティブ TOML フォーマットに適応し、本リポジトリで維持。 |
 | 7 | <img src="https://github.com/sehoon787.png?size=32" width="20" height="20" align="center"/> **[my-claude](https://github.com/sehoon787/my-claude)** — sehoon787 | 姉妹プロジェクト | ネイティブ Claude `.md` エージェントフォーマットで同じ Boss オーケストレーションを実現。スキル、ルール、Briefing Vault を両プロジェクトで共有。 |
+| 8 | <img src="https://github.com/getagentseal.png?size=32" width="20" height="20" align="center"/> **[codeburn](https://github.com/getagentseal/codeburn)** — getagentseal | npm CLI (MIT) | ローカルファーストのトークン/コストトラッカー。`~/.codex/sessions` を読み取り専用で解析 — プロキシ・アップロード不要。`install.sh` がインストール（`codeburn@0.9.23` に固定）、`upstream/SOURCES.json` に `method: npm-cli` として登録。Codex にはフックなし。 |
 
-すべてのサブモジュールは `upstream/SOURCES.json`（AI-BOM）で SHA 固定されており、削除された 2 つのサブモジュール（`agency-agents` — ベンダリングなし、`awesome-codex-subagents` — エージェント 17 個をベンダリング）も記録されています。
+すべてのサブモジュールは `upstream/SOURCES.json`（AI-BOM）（companion CLI（ast-grep、codeburn）も同じファイルにバージョン固定で登録されています）で SHA 固定されており、削除された 2 つのサブモジュール（`agency-agents` — ベンダリングなし、`awesome-codex-subagents` — エージェント 17 個をベンダリング）も記録されています。
 
 ---
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -121,6 +121,20 @@ Engineering review      Auto code review        Present comparison table
 Confirm "design done"   Architect verification  User: approve / improve
 ```
 
+### 정형화된 최종 보고
+
+Boss는 작업이 있던 모든 턴 — 파일 편집·생성, 커밋/PR/머지, 설정 변경, 검증 실행이 있었던 턴 — 을 diff를 열지 않고도 훑어볼 수 있는 정형화된 최종 보고로 마무리합니다. 보고는 고정된 표 5종으로 구성되며, 각 표는 해당 상황이 실제로 발생했을 때만 출력됩니다(빈 표는 만들지 않음):
+
+| 상황 | 표 | 컬럼 |
+|-----------|-------|---------|
+| 파일/설정 변경 | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
+| 여러 작업 완료 | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
+| 검증 실행 | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
+| 커밋/PR 산출 | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
+| 미해결 존재 | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+
+이 보고는 추론의 맨 마지막에만 발동하며 — 작업 중간의 진행 상황 보고로는 절대 출력되지 않음 — 순수 질답 턴은 보고 없이 정상 종료됩니다. 규격은 `boss.toml`의 developer instructions에 담겨 있습니다. (자매 프로젝트 [my-claude](https://github.com/sehoon787/my-claude)에서는 Stop 훅이 추가로 이를 강제하지만, Codex CLI에는 동등한 강제 지점이 없어 여기서는 프롬프트 수준의 규격입니다.)
+
 ---
 
 ## 아키텍처
@@ -352,7 +366,7 @@ BriefingVault v2는 세 가지 지식 관리 방법론을 통합합니다:
 
 ## 업스트림 오픈소스 출처
 
-my-codex는 **4개의 업스트림 서브모듈**과 벤더링된 스냅샷 1개, 적용/자매 프로젝트 2개로 구성됩니다:
+my-codex는 **4개의 업스트림 서브모듈**과 벤더링된 스냅샷 1개, 적용/자매 프로젝트 2개, companion CLI 1개로 구성됩니다:
 
 | # | 출처 | 방식 | 제공 내용 |
 |---|--------|------|-----------------|
@@ -363,8 +377,9 @@ my-codex는 **4개의 업스트림 서브모듈**과 벤더링된 스냅샷 1개
 | 5 | <img src="https://github.com/VoltAgent.png?size=32" width="20" height="20" align="center"/> **[awesome-codex-subagents](https://github.com/VoltAgent/awesome-codex-subagents)** — VoltAgent | 벤더링 (MIT) | AI/LLM 에이전트 17개를 `codex-agents/packs/`에 스냅샷하여 옵트인 팩 2개(data-ai 13, llmops 4)로 제공. 서브모듈은 2026-07-27에 제거되었습니다. |
 | 6 | <img src="https://github.com/code-yeongyu.png?size=32" width="20" height="20" align="center"/> **[oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)** — code-yeongyu | 적용 | OMO 에이전트 9개 (Sisyphus, Atlas, Oracle 등). Codex 네이티브 TOML 형식으로 적용하여 저장소에서 관리합니다. |
 | 7 | <img src="https://github.com/sehoon787.png?size=32" width="20" height="20" align="center"/> **[my-claude](https://github.com/sehoon787/my-claude)** — sehoon787 | 자매 프로젝트 | 네이티브 Claude `.md` 에이전트 형식의 동일한 Boss 오케스트레이션. 스킬, 규칙, Briefing Vault를 두 프로젝트가 공유합니다. |
+| 8 | <img src="https://github.com/getagentseal.png?size=32" width="20" height="20" align="center"/> **[codeburn](https://github.com/getagentseal/codeburn)** — getagentseal | npm CLI (MIT) | 로컬 우선 토큰/비용 추적기. `~/.codex/sessions`를 읽기 전용으로 파싱 — 프록시·업로드 없음. `install.sh`가 설치(`codeburn@0.9.23` 고정), `upstream/SOURCES.json`에 `method: npm-cli`로 등재. Codex에는 훅 없음. |
 
-모든 서브모듈은 `upstream/SOURCES.json`(AI-BOM)에 SHA로 고정되어 있으며, 제거된 서브모듈 2개(`agency-agents` — 벤더링 없음, `awesome-codex-subagents` — 에이전트 17개 벤더링)도 함께 기록됩니다.
+모든 서브모듈은 `upstream/SOURCES.json`(AI-BOM) — companion CLI(ast-grep, codeburn)도 같은 파일에 버전 고정으로 등재됩니다 —에 SHA로 고정되어 있으며, 제거된 서브모듈 2개(`agency-agents` — 벤더링 없음, `awesome-codex-subagents` — 에이전트 17개 벤더링)도 함께 기록됩니다.
 
 ---
 

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -121,6 +121,20 @@ Engineering review      Auto code review        Present comparison table
 Confirm "design done"   Architect verification  User: approve / improve
 ```
 
+### 结构化最终报告
+
+Boss 会以一份无需打开 diff 即可浏览的结构化最终报告来结束每个有实际工作的回合 — 即编辑/创建了文件、进行了提交/PR/合并、更改了配置或执行了验证的回合。报告由 5 个固定表格组成，每个表格仅在对应情况确实发生时才输出（绝不输出空表）:
+
+| 情况 | 表格 | 列 |
+|-----------|-------|---------|
+| 文件/设置变更 | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
+| 完成多项任务 | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
+| 执行了验证 | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
+| 产出提交/PR | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
+| 存在未解决项 | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+
+该报告仅在推理的最末尾触发 — 绝不会作为任务中途的进度更新输出 — 纯问答回合则正常结束、不生成报告。规范随 `boss.toml` 的 developer instructions 一起提供。（在姊妹项目 [my-claude](https://github.com/sehoon787/my-claude) 中还有一个 Stop 钩子额外强制执行；Codex CLI 没有等效的强制点，因此这里的规范是提示词级别的。）
+
 ---
 
 ## 架构
@@ -352,7 +366,7 @@ BriefingVault v2 整合了三种知识管理方法论：
 
 ## 上游开源来源
 
-my-codex 由 **4 个上游子模块**，加上 1 份内置快照与 2 个适配/姊妹项目组成：
+my-codex 由 **4 个上游子模块**，加上 1 份内置快照、2 个适配/姊妹项目与 1 个 companion CLI 组成：
 
 | # | 来源 | 方式 | 提供的内容 |
 |---|--------|------|-----------------|
@@ -363,8 +377,9 @@ my-codex 由 **4 个上游子模块**，加上 1 份内置快照与 2 个适配/
 | 5 | <img src="https://github.com/VoltAgent.png?size=32" width="20" height="20" align="center"/> **[awesome-codex-subagents](https://github.com/VoltAgent/awesome-codex-subagents)** — VoltAgent | 内置快照 (MIT) | 17 个 AI/LLM Agent 快照到 `codex-agents/packs/`，作为 2 个可选启用的包（data-ai 13、llmops 4）。子模块已于 2026-07-27 移除。 |
 | 6 | <img src="https://github.com/code-yeongyu.png?size=32" width="20" height="20" align="center"/> **[oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)** — code-yeongyu | 适配 | 9 个 OMO Agent（Sisyphus、Atlas、Oracle 等）。适配为 Codex 原生 TOML 格式并在本仓库维护。 |
 | 7 | <img src="https://github.com/sehoon787.png?size=32" width="20" height="20" align="center"/> **[my-claude](https://github.com/sehoon787/my-claude)** — sehoon787 | 姊妹项目 | 同样的 Boss 编排架构，原生 Claude `.md` Agent 格式。Skills、规则和 Briefing Vault 在两个项目间共享。 |
+| 8 | <img src="https://github.com/getagentseal.png?size=32" width="20" height="20" align="center"/> **[codeburn](https://github.com/getagentseal/codeburn)** — getagentseal | npm CLI (MIT) | 本地优先的 token/成本追踪器。只读解析 `~/.codex/sessions` — 无代理、不上传。由 `install.sh` 安装（固定 `codeburn@0.9.23`），在 `upstream/SOURCES.json` 中以 `method: npm-cli` 登记。Codex 上没有钩子。 |
 
-所有子模块均在 `upstream/SOURCES.json`（AI-BOM）中以 SHA 固定，该文件同时记录了两个已移除的子模块（`agency-agents` — 未内置任何内容；`awesome-codex-subagents` — 内置 17 个 Agent）。
+所有子模块均在 `upstream/SOURCES.json`（AI-BOM）（companion CLI（ast-grep、codeburn）也在同一文件中以固定版本登记）中以 SHA 固定，该文件同时记录了两个已移除的子模块（`agency-agents` — 未内置任何内容；`awesome-codex-subagents` — 内置 17 个 Agent）。
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -524,6 +524,7 @@ section{padding:80px 0}
     <div class="orig-card"><h4>Native TOML</h4><p><span class="lang" data-en="Zero-conversion agent format" data-ko="무변환 에이전트 형식"></span></p></div>
     <div class="orig-card"><h4>Dedup Guard</h4><p><span class="lang" data-en="Cross-source agent deduplication" data-ko="크로스 소스 에이전트 중복 제거"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Structured Final Report" data-ko="정형화된 최종 보고"></span></h4><p><span class="lang" data-en="Every working turn ends with fixed Before/After, verification, and deliverables tables" data-ko="작업이 있던 모든 턴을 Before/After·검증·산출물 고정 표로 마무리"></span></p></div>
+    <div class="orig-card"><h4><span class="lang" data-en="codeburn Cost Tracking" data-ko="codeburn 비용 추적"></span></h4><p><span class="lang" data-en="Local-first companion CLI that parses ~/.codex/sessions read-only and breaks token/cost down by model, project, and task — nothing leaves the machine" data-ko="~/.codex/sessions를 읽기 전용으로 파싱해 모델·프로젝트·작업별 토큰/비용을 집계하는 로컬 우선 companion CLI — 업로드 없음"></span></p></div>
   </div>
 </div>
 </section>


### PR DESCRIPTION
The English README gained a **Structured Final Report** section (#73) and a **codeburn** row (#74), but none of the five translated READMEs did, and the pages site had no codeburn card. Audited every marker across the ten files and brought them level with English.

| file | Final Report | codeburn row 8 | intro/AI-BOM sentence |
|---|---|---|---|
| ko / ja / zh / de / fr | ✅ | ✅ | ✅ |

- Final Report section placed exactly where the English one sits (after the 3-phase sprint), with the five-table spec and the honest note that enforcement is prompt-level here
- `docs/index.html`: "codeburn Cost Tracking" card (en/ko) — touching `docs/` is what triggers the Pages deploy, which the codeburn PR did not

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p