### PR TITLE
docs(boss): keep the English README and agent prompt English-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ Boss closes every working turn — any turn that edited files, made commits/PRs,
 
 | Situation | Table | Columns |
 |-----------|-------|---------|
-| Files/settings changed | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
-| Multiple tasks completed | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
-| Verification was run | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
-| Commits/PRs produced | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
-| Anything unresolved | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+| Files/settings changed | Changes | Target / Before / After / Rationale |
+| Multiple tasks completed | Work summary | Item / Result / Evidence |
+| Verification was run | Verification | Item / Expected / Actual / Verdict |
+| Commits/PRs produced | Deliverables | PR / Repo / Content / Status |
+| Anything unresolved | Remaining | Item / Status / Next step |
 
 It fires only at the very end of reasoning — never as a mid-task progress update — and pure Q&A turns end normally without it. The spec ships in `boss.toml`'s developer instructions. (In the sibling [my-claude](https://github.com/sehoon787/my-claude), a Stop hook additionally enforces it; the Codex CLI has no equivalent enforcement point, so here the spec is prompt-level.)
 

--- a/codex-agents/core/boss.toml
+++ b/codex-agents/core/boss.toml
@@ -133,15 +133,15 @@ Format: close your reply with a concise final report assembled from these tables
 
 | Situation | Table | Columns |
 |-----------|-------|---------|
-| Files/settings changed | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
-| Multiple tasks completed | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
-| Verification was run | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
-| Commits/PRs produced | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
-| Anything unresolved | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+| Files/settings changed | Changes | Target / Before / After / Rationale |
+| Multiple tasks completed | Work summary | Item / Result / Evidence |
+| Verification was run | Verification | Item / Expected / Actual / Verdict |
+| Commits/PRs produced | Deliverables | PR / Repo / Content / Status |
+| Anything unresolved | Remaining | Item / Status / Next step |
 
 Rules:
 - Before/After tables are MANDATORY whenever you modified existing files or settings.
-- Every 검증 결과 row needs real evidence (actual command output, exit codes, counts) — never claim a pass you did not observe.
-- 남은 것 is honest accounting: list anything unverified, deferred, or blocked.
-- Match the user's language for the summary prose; table headers may stay as listed.
+- Every Verification row needs real evidence (actual command output, exit codes, counts) — never claim a pass you did not observe.
+- Remaining is honest accounting: list anything unverified, deferred, or blocked.
+- Match the user's language for the prose AND the table names and headers alike — translate them; never leave English table headers in a non-English reply.
 """


### PR DESCRIPTION
The FINAL REPORT table shipped with **Korean table names and column headers inside the English README and the Boss agent definition**. English sources now use English names (Changes / Work summary / Verification / Deliverables / Remaining) and English columns.

The rule changes from "headers may stay as listed" to: *translate the table names and headers into the user's language alike* — so Korean users still get `변경 대조 / 대상 / Before / After / 근거` at reply time, and the translated READMEs (already localized) are unchanged.

Remaining Korean in the agent prompt is limited to the keyword→skill trigger line (e.g. "정기 감사" → `/cso`), which is functional routing for Korean input, not prose.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p