### PR TITLE
feat(models): roll the HIGH tier to gpt-6-astra

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ developer_instructions = """
 
 | Field | Values | Notes |
 |-------|--------|-------|
-| `model` | `"gpt-5.6-sol"`, `"gpt-5.6-luna"` | Defaults to `gpt-5.6-sol` if omitted |
+| `model` | `"gpt-6-astra"`, `"gpt-5.6-luna"` | Defaults to `gpt-6-astra` if omitted |
 | `model_reasoning_effort` | `"high"`, `"medium"`, `"low"` | Applies when model supports reasoning |
 | `sandbox_mode` | `"read-only"`, `"workspace-write"` | Use `read-only` for reviewers; `workspace-write` for implementers |
 | `nickname_candidates` | array of strings | Short invocation aliases |
@@ -68,7 +68,7 @@ developer_instructions = """
 
 | Model | Use For |
 |-------|---------|
-| `gpt-5.6-sol` | Standard development work, analysis, orchestration |
+| `gpt-6-astra` | Standard development work, analysis, orchestration |
 | `gpt-5.6-luna` | Fast lookups, lightweight agents, frequent invocation |
 
 **Sandbox mode guidance:**

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Boss cascades every request through a priority chain until the best match is fou
 
 | Complexity | Model | Used For |
 |-----------|-------|----------|
-| Deep analysis, architecture | gpt-5.6-sol (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
+| Deep analysis, architecture | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
 | Standard implementation | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
 | Quick lookup, exploration | gpt-5.6-luna (low) | explore, simple advisory |
 
@@ -154,7 +154,7 @@ It fires only at the very end of reasoning — never as a mid-task progress upda
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
+│  Boss · Meta-Orchestrator (gpt-6-astra xhigh)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -197,7 +197,7 @@ It fires only at the very end of reasoning — never as a mid-task progress upda
 
 | Agent | Model | Role | Source |
 |-------|-------|------|--------|
-| Boss | gpt-5.6-sol high | Dynamic runtime discovery → capability matching → optimal routing. Never writes code. | my-codex |
+| Boss | gpt-6-astra xhigh | Dynamic runtime discovery → capability matching → optimal routing. Never writes code. | my-codex |
 
 </details>
 
@@ -206,13 +206,13 @@ It fires only at the very end of reasoning — never as a mid-task progress upda
 
 | Agent | Model | Role | Source |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6-sol high | Intent classification → specialist delegation → verification | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6-sol high | Autonomous explore → plan → execute → verify | oh-my-openagent |
-| Atlas | gpt-5.6-sol high | Task decomposition + 4-stage QA verification | oh-my-openagent |
-| Oracle | gpt-5.6-sol high | Strategic technical consulting (read-only) | oh-my-openagent |
-| Metis | gpt-5.6-sol high | Intent analysis, ambiguity detection | oh-my-openagent |
-| Momus | gpt-5.6-sol high | Plan feasibility review | oh-my-openagent |
-| Prometheus | gpt-5.6-sol high | Interview-based detailed planning | oh-my-openagent |
+| Sisyphus | gpt-6-astra high | Intent classification → specialist delegation → verification | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-6-astra high | Autonomous explore → plan → execute → verify | oh-my-openagent |
+| Atlas | gpt-6-astra high | Task decomposition + 4-stage QA verification | oh-my-openagent |
+| Oracle | gpt-6-astra xhigh | Strategic technical consulting (read-only) | oh-my-openagent |
+| Metis | gpt-6-astra high | Intent analysis, ambiguity detection | oh-my-openagent |
+| Momus | gpt-6-astra high | Plan feasibility review | oh-my-openagent |
+| Prometheus | gpt-6-astra xhigh | Interview-based detailed planning | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | Open-source documentation search via MCP | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | Image/screenshot/diagram analysis | oh-my-openagent |
 
@@ -434,7 +434,7 @@ Features built specifically for this project, beyond what upstream sources provi
 | **Boss Meta-Orchestrator** | Dynamic capability discovery → intent classification → 4-priority routing → delegation → verification |
 | **3-Phase Sprint** | Design (interactive) → Execute (autonomous via executor) → Review (interactive vs design doc) |
 | **Agent Tier Priority** | core > omo > omx > opt-in packs. Pack agents are skipped if their name collides with an already-installed agent. Most specialized agent wins. |
-| **Cost Optimization** | gpt-5.6-luna for advisory, gpt-5.6-sol for implementation — automatic model routing across all 34 installed agents |
+| **Cost Optimization** | gpt-5.6-luna for advisory, gpt-6-astra for implementation — automatic model routing across all 34 installed agents |
 | **Briefing Signals** | Wrapper/session logging feeds `.briefing/agents/agent-log.jsonl`, daily summaries, and routing/profile hints |
 | **Smart Packs** | Project-type detection recommends relevant agent packs at session start |
 | **Agent Pack System** | On-demand domain specialist activation via `--profile` and `my-codex-packs` helper |
@@ -565,7 +565,7 @@ A GitHub Actions workflow runs every 3 days, pulling the latest commits from all
 <details>
 <summary><strong>What models does my-codex use?</strong></summary>
 
-Boss and sub-orchestrators (Sisyphus, Atlas, Oracle) use gpt-5.6-sol with high reasoning effort. Standard workers use gpt-5.6-terra with medium reasoning. Lightweight advisory agents use gpt-5.6-luna.
+Boss and sub-orchestrators (Sisyphus, Atlas, Oracle) use gpt-6-astra with high reasoning effort (Boss, Oracle, and Prometheus at xhigh). Standard workers use gpt-5.6-terra with medium reasoning. Lightweight advisory agents use gpt-5.6-luna.
 
 Skills consume the SKILL.md standard as-is with no transformation; only agents are converted to Codex TOML, and the model tier for that conversion is managed from a single file, `scripts/model-tiers.sh`. When Codex ships its next model generation, update only that file — `scripts/md-to-toml.sh` and `install.sh` both source it.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -175,7 +175,7 @@ Codex CLI uses OpenAI reasoning models. Route tasks by complexity:
 
 | Model | Reasoning Effort | Use For |
 |---|---|---|
-| gpt-5.6-sol (high) | Deep | Architecture, complex analysis, security review |
+| gpt-6-astra (high) | Deep | Architecture, complex analysis, security review |
 | gpt-5.6-terra (medium) | Standard | Implementation, code review, debugging |
 | gpt-5.6-luna (low) | Fast | Quick lookups, exploration, trivial changes |
 
@@ -188,7 +188,7 @@ multi_agent = true
 
 Override per-session:
 ```bash
-codex --model gpt-5.6-sol --reasoning-effort high "Design the auth system"
+codex --model gpt-6-astra --reasoning-effort high "Design the auth system"
 ```
 
 ---
@@ -223,7 +223,7 @@ to dependent tasks.
 
 ```
 You are boss. The goal is to add OAuth2 support.
-1. Use architect to design the approach (spawn with model=gpt-5.6-sol, effort=high)
+1. Use architect to design the approach (spawn with model=gpt-6-astra, effort=high)
 2. Use planner to create task breakdown
 3. Spawn executor agents for each implementation task (parallel where safe)
 4. Use code-reviewer to review all changes

--- a/codex-agents/core/boss.toml
+++ b/codex-agents/core/boss.toml
@@ -1,6 +1,6 @@
 name = "boss"
 description = "Use when the user's request needs dynamic agent discovery, intent classification, and delegation to the optimal specialist."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/atlas.toml
+++ b/codex-agents/omo/atlas.toml
@@ -1,6 +1,6 @@
 name = "atlas"
 description = "Use when a work plan already exists and each step needs delegation, sequencing, and verification; returns a task-by-task status table with the evidence checked for each completed step."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/hephaestus.toml
+++ b/codex-agents/omo/hephaestus.toml
@@ -1,6 +1,6 @@
 name = "hephaestus"
 description = "Use when one agent should finish a task end-to-end without check-ins or delegation — explores, plans, implements, and verifies on its own; returns the implemented changes plus test and verification output."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/omo/metis.toml
+++ b/codex-agents/omo/metis.toml
@@ -1,6 +1,6 @@
 name = "metis"
 description = "Use before planning starts when a request may be ambiguous, over-scoped, or misread; returns an intent classification, the ambiguities found, and the clarifying questions to ask first."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/momus.toml
+++ b/codex-agents/omo/momus.toml
@@ -1,6 +1,6 @@
 name = "momus"
 description = "Use when a finished work plan needs an executability check before anyone starts building; returns blocking issues only, each with the plan location and a concrete fix. Read-only."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/oracle.toml
+++ b/codex-agents/omo/oracle.toml
@@ -1,6 +1,6 @@
 name = "oracle"
 description = "Use when an architecture decision or a stuck bug needs a deep read-only second opinion; returns a reasoned recommendation with tradeoffs, risks, and the next concrete step. Changes nothing."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/prometheus.toml
+++ b/codex-agents/omo/prometheus.toml
@@ -1,6 +1,6 @@
 name = "prometheus"
 description = "Use when a request needs a plan before any code is written — runs a structured interview and researches the codebase; returns a markdown work plan with phases, ordered steps, and acceptance criteria."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/sisyphus.toml
+++ b/codex-agents/omo/sisyphus.toml
@@ -1,6 +1,6 @@
 name = "sisyphus"
 description = "Use when a multi-step request has no plan yet and needs relentless end-to-end orchestration — classifies intent, delegates to specialists, and re-delegates until every result verifies; returns a completion report with per-task verification evidence. Never writes code."
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -104,7 +104,7 @@ Boss leitet jede Anfrage durch eine Prioritätskette, bis die beste Übereinstim
 
 | Komplexität | Modell | Verwendet für |
 |-------------|--------|---------------|
-| Tiefgehende Analyse, Architektur | gpt-5.6-sol (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
+| Tiefgehende Analyse, Architektur | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
 | Standardimplementierung | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
 | Schnelle Suche, Erkundung | gpt-5.6-luna (low) | explore, einfache Beratung |
 
@@ -145,7 +145,7 @@ Er wird nur ganz am Ende des Reasonings ausgelöst — niemals als Fortschrittsm
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
+│  Boss · Meta-Orchestrator (gpt-6-astra xhigh)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -188,7 +188,7 @@ Er wird nur ganz am Ende des Reasonings ausgelöst — niemals als Fortschrittsm
 
 | Agent | Modell | Rolle | Quelle |
 |-------|--------|-------|--------|
-| Boss | gpt-5.6-sol high | Dynamische Laufzeitentdeckung → Fähigkeitsabgleich → optimales Routing. Schreibt niemals Code. | my-codex |
+| Boss | gpt-6-astra xhigh | Dynamische Laufzeitentdeckung → Fähigkeitsabgleich → optimales Routing. Schreibt niemals Code. | my-codex |
 
 </details>
 
@@ -197,13 +197,13 @@ Er wird nur ganz am Ende des Reasonings ausgelöst — niemals als Fortschrittsm
 
 | Agent | Modell | Rolle | Quelle |
 |-------|--------|-------|--------|
-| Sisyphus | gpt-5.6-sol high | Absichtsklassifizierung → Spezialistendelegation → Verifikation | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6-sol high | Autonom erkunden → planen → ausführen → verifizieren | oh-my-openagent |
-| Atlas | gpt-5.6-sol high | Aufgabenzerlegung + 4-stufige QA-Verifikation | oh-my-openagent |
-| Oracle | gpt-5.6-sol high | Strategische technische Beratung (nur lesend) | oh-my-openagent |
-| Metis | gpt-5.6-sol high | Absichtsanalyse, Mehrdeutigkeitserkennung | oh-my-openagent |
-| Momus | gpt-5.6-sol high | Überprüfung der Planumsetzbarkeit | oh-my-openagent |
-| Prometheus | gpt-5.6-sol high | Interviewbasierte detaillierte Planung | oh-my-openagent |
+| Sisyphus | gpt-6-astra high | Absichtsklassifizierung → Spezialistendelegation → Verifikation | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-6-astra high | Autonom erkunden → planen → ausführen → verifizieren | oh-my-openagent |
+| Atlas | gpt-6-astra high | Aufgabenzerlegung + 4-stufige QA-Verifikation | oh-my-openagent |
+| Oracle | gpt-6-astra xhigh | Strategische technische Beratung (nur lesend) | oh-my-openagent |
+| Metis | gpt-6-astra high | Absichtsanalyse, Mehrdeutigkeitserkennung | oh-my-openagent |
+| Momus | gpt-6-astra high | Überprüfung der Planumsetzbarkeit | oh-my-openagent |
+| Prometheus | gpt-6-astra xhigh | Interviewbasierte detaillierte Planung | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | Open-Source-Dokumentationssuche über MCP | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | Bild-/Screenshot-/Diagrammanalyse | oh-my-openagent |
 
@@ -406,7 +406,7 @@ Funktionen, die speziell für dieses Projekt entwickelt wurden und über das hin
 | **Boss Meta-Orchestrator** | Dynamische Fähigkeitsentdeckung → Absichtsklassifizierung → 4-Prioritäten-Routing → Delegation → Verifikation |
 | **3-Phasen-Sprint** | Design (interaktiv) → Ausführung (autonom über executor) → Review (interaktiv vs. Design-Dokument) |
 | **Agenten-Tier-Priorität** | core > omo > omx > Opt-in-Packs. Pack-Agenten mit Namenskollision zu einem bereits installierten Agenten werden übersprungen. Der speziellste Agent gewinnt. |
-| **Kostenoptimierung** | gpt-5.6-luna für Beratung, gpt-5.6-sol für Implementierung — automatisches Modell-Routing über alle 34 installierten Agenten |
+| **Kostenoptimierung** | gpt-5.6-luna für Beratung, gpt-6-astra für Implementierung — automatisches Modell-Routing über alle 34 installierten Agenten |
 | **Agenten-Telemetrie** | PostToolUse-Hook protokolliert Agentennutzung in `agent-usage.jsonl` |
 | **Smart Packs** | Projekttypenerkennung empfiehlt relevante Agenten-Packs beim Sitzungsstart |
 | **Agenten-Pack-System** | On-demand-Domänenspezialisten-Aktivierung über `--profile` und `my-codex-packs`-Hilfsprogramm |
@@ -537,7 +537,7 @@ Ein GitHub Actions-Workflow läuft alle 3 Tage, zieht die neuesten Commits aus a
 <details>
 <summary><strong>Welche Modelle verwendet my-codex?</strong></summary>
 
-Boss und Sub-Orchestratoren (Sisyphus, Atlas, Oracle) verwenden gpt-5.6-sol mit hohem Reasoning-Aufwand. Standard-Worker verwenden gpt-5.6-terra mit mittlerem Reasoning. Leichtgewichtige Beratungsagenten verwenden gpt-5.6-luna.
+Boss und Sub-Orchestratoren (Sisyphus, Atlas, Oracle) verwenden gpt-6-astra mit hohem Reasoning-Aufwand. Standard-Worker verwenden gpt-5.6-terra mit mittlerem Reasoning. Leichtgewichtige Beratungsagenten verwenden gpt-5.6-luna.
 
 </details>
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -108,7 +108,7 @@ Boss cascade chaque requête dans une chaîne de priorités jusqu'à trouver la 
 
 | Complexité | Modèle | Utilisé pour |
 |-----------|-------|----------|
-| Analyse approfondie, architecture | gpt-5.6-sol (raisonnement élevé) | Boss, Oracle, Sisyphus, Atlas |
+| Analyse approfondie, architecture | gpt-6-astra (raisonnement high/xhigh) | Boss, Oracle, Sisyphus, Atlas |
 | Implémentation standard | gpt-5.6-terra (moyen) | executor, debugger, security-reviewer |
 | Recherche rapide, exploration | gpt-5.6-luna (faible) | explore, conseil simple |
 
@@ -152,7 +152,7 @@ Il ne se déclenche qu'à la toute fin du raisonnement — jamais comme point d'
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Méta-Orchestrateur (gpt-5.6-sol high)             │
+│  Boss · Méta-Orchestrateur (gpt-6-astra xhigh)             │
 │  Découverte → Classification → Correspondance →       │
 │  Délégation                                           │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
@@ -198,7 +198,7 @@ Il ne se déclenche qu'à la toute fin du raisonnement — jamais comme point d'
 
 | Agent | Modèle | Rôle | Source |
 |-------|-------|------|--------|
-| Boss | gpt-5.6-sol high | Découverte dynamique à l'exécution → correspondance de capacités → routage optimal. N'écrit jamais de code. | my-codex |
+| Boss | gpt-6-astra xhigh | Découverte dynamique à l'exécution → correspondance de capacités → routage optimal. N'écrit jamais de code. | my-codex |
 
 </details>
 
@@ -207,13 +207,13 @@ Il ne se déclenche qu'à la toute fin du raisonnement — jamais comme point d'
 
 | Agent | Modèle | Rôle | Source |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6-sol high | Classification d'intention → délégation aux spécialistes → vérification | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6-sol high | Exploration autonome → planification → exécution → vérification | oh-my-openagent |
-| Atlas | gpt-5.6-sol high | Décomposition de tâches + vérification QA en 4 étapes | oh-my-openagent |
-| Oracle | gpt-5.6-sol high | Conseil technique stratégique (lecture seule) | oh-my-openagent |
-| Metis | gpt-5.6-sol high | Analyse d'intention, détection d'ambiguïté | oh-my-openagent |
-| Momus | gpt-5.6-sol high | Révision de faisabilité des plans | oh-my-openagent |
-| Prometheus | gpt-5.6-sol high | Planification détaillée par entretien | oh-my-openagent |
+| Sisyphus | gpt-6-astra high | Classification d'intention → délégation aux spécialistes → vérification | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-6-astra high | Exploration autonome → planification → exécution → vérification | oh-my-openagent |
+| Atlas | gpt-6-astra high | Décomposition de tâches + vérification QA en 4 étapes | oh-my-openagent |
+| Oracle | gpt-6-astra xhigh | Conseil technique stratégique (lecture seule) | oh-my-openagent |
+| Metis | gpt-6-astra high | Analyse d'intention, détection d'ambiguïté | oh-my-openagent |
+| Momus | gpt-6-astra high | Révision de faisabilité des plans | oh-my-openagent |
+| Prometheus | gpt-6-astra xhigh | Planification détaillée par entretien | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | Recherche de documentation open source via MCP | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | Analyse d'images, captures d'écran et diagrammes | oh-my-openagent |
 
@@ -416,7 +416,7 @@ Fonctionnalités construites spécifiquement pour ce projet, au-delà de ce que 
 | **Boss Méta-Orchestrateur** | Découverte dynamique des capacités → classification d'intention → routage à 4 priorités → délégation → vérification |
 | **Sprint 3 phases** | Conception (interactive) → Exécution (autonome via executor) → Révision (interactive vs doc de conception) |
 | **Priorité par niveau d'agent** | core > omo > omx > packs optionnels. Un agent de pack dont le nom entre en collision avec un agent déjà installé est ignoré. L'agent le plus spécialisé l'emporte. |
-| **Optimisation des coûts** | gpt-5.6-luna pour le conseil, gpt-5.6-sol pour l'implémentation — routage de modèle automatique sur les 34 agents installés |
+| **Optimisation des coûts** | gpt-5.6-luna pour le conseil, gpt-6-astra pour l'implémentation — routage de modèle automatique sur les 34 agents installés |
 | **Télémétrie des agents** | Le hook PostToolUse enregistre l'utilisation des agents dans `agent-usage.jsonl` |
 | **Smart Packs** | La détection du type de projet recommande les packs d'agents pertinents au démarrage de session |
 | **Système de packs d'agents** | Activation de spécialistes de domaine à la demande via `--profile` et l'aide `my-codex-packs` |
@@ -547,7 +547,7 @@ Un workflow GitHub Actions s'exécute tous les 3 jours, récupérant les dernier
 <details>
 <summary><strong>Quels modèles utilise my-codex ?</strong></summary>
 
-Boss et les sous-orchestrateurs (Sisyphus, Atlas, Oracle) utilisent gpt-5.6-sol avec un niveau de raisonnement élevé. Les agents de travail standard utilisent gpt-5.6-terra avec un raisonnement moyen. Les agents de conseil légers utilisent gpt-5.6-luna.
+Boss et les sous-orchestrateurs (Sisyphus, Atlas, Oracle) utilisent gpt-6-astra avec un niveau de raisonnement élevé. Les agents de travail standard utilisent gpt-5.6-terra avec un raisonnement moyen. Les agents de conseil légers utilisent gpt-5.6-luna.
 
 </details>
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -104,7 +104,7 @@ Boss はすべてのリクエストを優先チェーンにカスケードし、
 
 | 複雑度 | モデル | 使用場面 |
 |-----------|-------|----------|
-| 深い分析、アーキテクチャ | gpt-5.6-sol (high reasoning) | Boss、Oracle、Sisyphus、Atlas |
+| 深い分析、アーキテクチャ | gpt-6-astra (high/xhigh reasoning) | Boss、Oracle、Sisyphus、Atlas |
 | 標準的な実装 | gpt-5.6-terra (medium) | executor、debugger、security-reviewer |
 | 簡単な検索、調査 | gpt-5.6-luna (low) | explore、簡易アドバイザリー |
 
@@ -145,7 +145,7 @@ Boss は作業が発生したすべてのターン — ファイルの編集・�
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
+│  Boss · Meta-Orchestrator (gpt-6-astra xhigh)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -188,7 +188,7 @@ Boss は作業が発生したすべてのターン — ファイルの編集・�
 
 | エージェント | モデル | 役割 | ソース |
 |-------|-------|------|--------|
-| Boss | gpt-5.6-sol high | ダイナミックランタイム検出 → ケイパビリティマッチング → 最適ルーティング。コードは書かない。 | my-codex |
+| Boss | gpt-6-astra xhigh | ダイナミックランタイム検出 → ケイパビリティマッチング → 最適ルーティング。コードは書かない。 | my-codex |
 
 </details>
 
@@ -197,13 +197,13 @@ Boss は作業が発生したすべてのターン — ファイルの編集・�
 
 | エージェント | モデル | 役割 | ソース |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6-sol high | インテント分類 → スペシャリスト委任 → 検証 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6-sol high | 自律的な調査 → 計画 → 実行 → 検証 | oh-my-openagent |
-| Atlas | gpt-5.6-sol high | タスク分解 + 4 ステージ QA 検証 | oh-my-openagent |
-| Oracle | gpt-5.6-sol high | 戦略的技術コンサルティング（読み取り専用） | oh-my-openagent |
-| Metis | gpt-5.6-sol high | インテント分析、曖昧さ検出 | oh-my-openagent |
-| Momus | gpt-5.6-sol high | 計画実現可能性レビュー | oh-my-openagent |
-| Prometheus | gpt-5.6-sol high | インタビューベースの詳細計画立案 | oh-my-openagent |
+| Sisyphus | gpt-6-astra high | インテント分類 → スペシャリスト委任 → 検証 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-6-astra high | 自律的な調査 → 計画 → 実行 → 検証 | oh-my-openagent |
+| Atlas | gpt-6-astra high | タスク分解 + 4 ステージ QA 検証 | oh-my-openagent |
+| Oracle | gpt-6-astra xhigh | 戦略的技術コンサルティング（読み取り専用） | oh-my-openagent |
+| Metis | gpt-6-astra high | インテント分析、曖昧さ検出 | oh-my-openagent |
+| Momus | gpt-6-astra high | 計画実現可能性レビュー | oh-my-openagent |
+| Prometheus | gpt-6-astra xhigh | インタビューベースの詳細計画立案 | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | MCP 経由のオープンソースドキュメント検索 | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | 画像・スクリーンショット・図の分析 | oh-my-openagent |
 
@@ -406,7 +406,7 @@ my-codex は **4 つのアップストリームサブモジュール**に加え�
 | **Boss メタオーケストレーター** | ダイナミックケイパビリティ検出 → インテント分類 → 4 優先ルーティング → 委任 → 検証 |
 | **3 フェーズスプリント** | 設計（インタラクティブ）→ 実行（executor による自律）→ レビュー（設計書との比較インタラクティブ） |
 | **エージェント層優先度** | core > omo > omx > オプトインパックの順で重複排除。既存エージェントと名前が衝突するパックエージェントはスキップ。最も特化したエージェントが優先。 |
-| **コスト最適化** | アドバイザリーには gpt-5.6-luna、実装には gpt-5.6-sol — インストール済み 34 エージェント全体への自動モデルルーティング |
+| **コスト最適化** | アドバイザリーには gpt-5.6-luna、実装には gpt-6-astra — インストール済み 34 エージェント全体への自動モデルルーティング |
 | **エージェントテレメトリー** | PostToolUse フックがエージェント使用状況を `agent-usage.jsonl` に記録 |
 | **スマートパック** | プロジェクトタイプ検出がセッション開始時に関連エージェントパックを推奨 |
 | **エージェントパックシステム** | `--profile` と `my-codex-packs` ヘルパーによるオンデマンドのドメインスペシャリスト有効化 |
@@ -537,7 +537,7 @@ GitHub Actions ワークフローが 3 日ごとに実行され、4 つのアッ
 <details>
 <summary><strong>my-codex が使用するモデルは何ですか？</strong></summary>
 
-Boss とサブオーケストレーター（Sisyphus、Atlas、Oracle）は高い推論努力で gpt-5.6-sol を使用します。標準ワーカーは中程度の推論で gpt-5.6-terra を使用します。軽量アドバイザリーエージェントは gpt-5.6-luna を使用します。
+Boss とサブオーケストレーター（Sisyphus、Atlas、Oracle）は高い推論努力で gpt-6-astra を使用します。標準ワーカーは中程度の推論で gpt-5.6-terra を使用します。軽量アドバイザリーエージェントは gpt-5.6-luna を使用します。
 
 </details>
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -104,7 +104,7 @@ Boss는 가장 적합한 매칭을 찾을 때까지 모든 요청을 우선순�
 
 | 복잡도 | 모델 | 사용 대상 |
 |-----------|-------|----------|
-| 심층 분석, 아키텍처 | gpt-5.6-sol (high reasoning) | Boss, Oracle, Sisyphus, Atlas |
+| 심층 분석, 아키텍처 | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
 | 표준 구현 | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
 | 빠른 조회, 탐색 | gpt-5.6-luna (low) | explore, 간단한 자문 |
 
@@ -145,7 +145,7 @@ Boss는 작업이 있던 모든 턴 — 파일 편집·생성, 커밋/PR/머지,
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
+│  Boss · Meta-Orchestrator (gpt-6-astra xhigh)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -188,7 +188,7 @@ Boss는 작업이 있던 모든 턴 — 파일 편집·생성, 커밋/PR/머지,
 
 | 에이전트 | 모델 | 역할 | 출처 |
 |-------|-------|------|--------|
-| Boss | gpt-5.6-sol high | 동적 런타임 탐색 → 역량 매칭 → 최적 라우팅. 코드를 직접 작성하지 않습니다. | my-codex |
+| Boss | gpt-6-astra xhigh | 동적 런타임 탐색 → 역량 매칭 → 최적 라우팅. 코드를 직접 작성하지 않습니다. | my-codex |
 
 </details>
 
@@ -197,13 +197,13 @@ Boss는 작업이 있던 모든 턴 — 파일 편집·생성, 커밋/PR/머지,
 
 | 에이전트 | 모델 | 역할 | 출처 |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6-sol high | 의도 분류 → 전문가 위임 → 검증 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6-sol high | 자율적 탐색 → 계획 → 실행 → 검증 | oh-my-openagent |
-| Atlas | gpt-5.6-sol high | 작업 분해 + 4단계 QA 검증 | oh-my-openagent |
-| Oracle | gpt-5.6-sol high | 전략적 기술 컨설팅 (읽기 전용) | oh-my-openagent |
-| Metis | gpt-5.6-sol high | 의도 분석, 모호성 탐지 | oh-my-openagent |
-| Momus | gpt-5.6-sol high | 계획 실현 가능성 검토 | oh-my-openagent |
-| Prometheus | gpt-5.6-sol high | 인터뷰 기반 세부 계획 수립 | oh-my-openagent |
+| Sisyphus | gpt-6-astra high | 의도 분류 → 전문가 위임 → 검증 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-6-astra high | 자율적 탐색 → 계획 → 실행 → 검증 | oh-my-openagent |
+| Atlas | gpt-6-astra high | 작업 분해 + 4단계 QA 검증 | oh-my-openagent |
+| Oracle | gpt-6-astra xhigh | 전략적 기술 컨설팅 (읽기 전용) | oh-my-openagent |
+| Metis | gpt-6-astra high | 의도 분석, 모호성 탐지 | oh-my-openagent |
+| Momus | gpt-6-astra high | 계획 실현 가능성 검토 | oh-my-openagent |
+| Prometheus | gpt-6-astra xhigh | 인터뷰 기반 세부 계획 수립 | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | MCP를 통한 오픈소스 문서 검색 | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | 이미지/스크린샷/다이어그램 분석 | oh-my-openagent |
 
@@ -406,7 +406,7 @@ my-codex는 **4개의 업스트림 서브모듈**과 벤더링된 스냅샷 1개
 | **Boss 메타 오케스트레이터** | 동적 역량 탐색 → 의도 분류 → 4단계 우선순위 라우팅 → 위임 → 검증 |
 | **3단계 스프린트** | 설계 (대화형) → 실행 (executor를 통한 자율) → 리뷰 (설계 문서와 대화형 비교) |
 | **에이전트 티어 우선순위** | core > omo > omx > 옵트인 팩 순으로 중복 제거. 이미 설치된 에이전트와 이름이 겹치는 팩 에이전트는 건너뜁니다. 가장 특화된 에이전트가 선택됩니다. |
-| **비용 최적화** | 자문에는 gpt-5.6-luna, 구현에는 gpt-5.6-sol — 설치된 34개 에이전트 전체에 대한 자동 모델 라우팅 |
+| **비용 최적화** | 자문에는 gpt-5.6-luna, 구현에는 gpt-6-astra — 설치된 34개 에이전트 전체에 대한 자동 모델 라우팅 |
 | **에이전트 텔레메트리** | PostToolUse 훅이 에이전트 사용량을 `agent-usage.jsonl`에 기록 |
 | **Smart Packs** | 프로젝트 유형 감지로 세션 시작 시 관련 에이전트 팩 추천 |
 | **에이전트 팩 시스템** | `--profile` 및 `my-codex-packs` 헬퍼를 통한 온디맨드 도메인 전문가 활성화 |
@@ -537,7 +537,7 @@ GitHub Actions 워크플로가 3일마다 실행되어 4개 업스트림 서브�
 <details>
 <summary><strong>my-codex는 어떤 모델을 사용하나요?</strong></summary>
 
-Boss와 서브 오케스트레이터(Sisyphus, Atlas, Oracle)는 high reasoning effort의 gpt-5.6-sol를 사용합니다. 표준 작업자는 medium reasoning의 gpt-5.6-terra를 사용합니다. 경량 자문 에이전트는 gpt-5.6-luna를 사용합니다.
+Boss와 서브 오케스트레이터(Sisyphus, Atlas, Oracle)는 high reasoning effort의 gpt-6-astra를 사용합니다. 표준 작업자는 medium reasoning의 gpt-5.6-terra를 사용합니다. 경량 자문 에이전트는 gpt-5.6-luna를 사용합니다.
 
 </details>
 

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -104,7 +104,7 @@ Boss 对每个请求按优先级链逐级匹配，直到找到最佳方案：
 
 | 复杂度 | 模型 | 用途 |
 |-----------|-------|----------|
-| 深度分析、架构 | gpt-5.6-sol（high reasoning） | Boss、Oracle、Sisyphus、Atlas |
+| 深度分析、架构 | gpt-6-astra （high/xhigh reasoning） | Boss、Oracle、Sisyphus、Atlas |
 | 标准实现 | gpt-5.6-terra（medium） | executor、debugger、security-reviewer |
 | 快速查询、探索 | gpt-5.6-luna（low） | explore、简单咨询 |
 
@@ -145,7 +145,7 @@ Boss 会以一份无需打开 diff 即可浏览的结构化最终报告来结束
 └───────────────────────┬─────────────────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────┐
-│  Boss · Meta-Orchestrator (gpt-5.6-sol high)              │
+│  Boss · Meta-Orchestrator (gpt-6-astra xhigh)              │
 │  Discovery → Classification → Matching → Delegation  │
 └──┬──────────┬──────────┬──────────┬─────────────────┘
    │          │          │          │
@@ -188,7 +188,7 @@ Boss 会以一份无需打开 diff 即可浏览的结构化最终报告来结束
 
 | Agent | 模型 | 角色 | 来源 |
 |-------|-------|------|--------|
-| Boss | gpt-5.6-sol high | 动态运行时发现 → 能力匹配 → 最优路由。从不编写代码。 | my-codex |
+| Boss | gpt-6-astra xhigh | 动态运行时发现 → 能力匹配 → 最优路由。从不编写代码。 | my-codex |
 
 </details>
 
@@ -197,13 +197,13 @@ Boss 会以一份无需打开 diff 即可浏览的结构化最终报告来结束
 
 | Agent | 模型 | 角色 | 来源 |
 |-------|-------|------|--------|
-| Sisyphus | gpt-5.6-sol high | 意图分类 → 专家委派 → 验证 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
-| Hephaestus | gpt-5.6-sol high | 自主探索 → 规划 → 执行 → 验证 | oh-my-openagent |
-| Atlas | gpt-5.6-sol high | 任务分解 + 四阶段 QA 验证 | oh-my-openagent |
-| Oracle | gpt-5.6-sol high | 战略技术咨询（只读） | oh-my-openagent |
-| Metis | gpt-5.6-sol high | 意图分析、歧义检测 | oh-my-openagent |
-| Momus | gpt-5.6-sol high | 计划可行性评审 | oh-my-openagent |
-| Prometheus | gpt-5.6-sol high | 基于访谈的详细规划 | oh-my-openagent |
+| Sisyphus | gpt-6-astra high | 意图分类 → 专家委派 → 验证 | [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) |
+| Hephaestus | gpt-6-astra high | 自主探索 → 规划 → 执行 → 验证 | oh-my-openagent |
+| Atlas | gpt-6-astra high | 任务分解 + 四阶段 QA 验证 | oh-my-openagent |
+| Oracle | gpt-6-astra xhigh | 战略技术咨询（只读） | oh-my-openagent |
+| Metis | gpt-6-astra high | 意图分析、歧义检测 | oh-my-openagent |
+| Momus | gpt-6-astra high | 计划可行性评审 | oh-my-openagent |
+| Prometheus | gpt-6-astra xhigh | 基于访谈的详细规划 | oh-my-openagent |
 | Librarian | gpt-5.6-terra medium | 通过 MCP 搜索开源文档 | oh-my-openagent |
 | Multimodal-Looker | gpt-5.6-terra medium | 图像 / 截图 / 图表分析 | oh-my-openagent |
 
@@ -406,7 +406,7 @@ my-codex 由 **4 个上游子模块**，加上 1 份内置快照、2 个适配/�
 | **Boss 元编排器** | 动态能力发现 → 意图分类 → 4 级优先路由 → 委派 → 验证 |
 | **三阶段冲刺** | 设计（交互式）→ 执行（通过 executor 自主进行）→ 审查（交互式对比设计文档） |
 | **Agent 层级优先级** | core > omo > omx > 可选包 依次去重。与已安装 Agent 同名的包内 Agent 会被跳过。最专业的 Agent 优先。 |
-| **成本优化** | 咨询用 gpt-5.6-luna，实现用 gpt-5.6-sol——覆盖全部 34 个已安装 Agent 的自动模型路由 |
+| **成本优化** | 咨询用 gpt-5.6-luna，实现用 gpt-6-astra——覆盖全部 34 个已安装 Agent 的自动模型路由 |
 | **Agent 遥测** | PostToolUse hook 将 Agent 使用情况记录到 `agent-usage.jsonl` |
 | **智能包** | 项目类型检测在会话开始时推荐相关 Agent 包 |
 | **Agent 包系统** | 通过 `--profile` 和 `my-codex-packs` 助手按需激活领域专家 |
@@ -537,7 +537,7 @@ GitHub Actions 工作流每 3 天运行一次，从 4 个上游子模块拉取�
 <details>
 <summary><strong>my-codex 使用哪些模型？</strong></summary>
 
-Boss 和子编排器（Sisyphus、Atlas、Oracle）使用 gpt-5.6-sol 高推理强度。标准工作者使用 gpt-5.6-terra 中等推理强度。轻量级咨询 Agent 使用 gpt-5.6-luna。
+Boss 和子编排器（Sisyphus、Atlas、Oracle）使用 gpt-6-astra 高推理强度。标准工作者使用 gpt-5.6-terra 中等推理强度。轻量级咨询 Agent 使用 gpt-5.6-luna。
 
 </details>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -287,7 +287,7 @@ section{padding:80px 0}
       <h3 style="font-size:1rem;margin-bottom:12px;color:var(--accent)"><span class="lang" data-en="Model Routing" data-ko="모델 라우팅"></span></h3>
       <table class="route-table">
         <tr><th><span class="lang" data-en="Complexity" data-ko="복잡도"></span></th><th><span class="lang" data-en="Model" data-ko="모델"></span></th></tr>
-        <tr><td style="color:var(--primary)"><span class="lang" data-en="Architecture, deep analysis" data-ko="아키텍처, 심층 분석"></span></td><td>gpt-5.6-sol (high)</td></tr>
+        <tr><td style="color:var(--primary)"><span class="lang" data-en="Architecture, deep analysis" data-ko="아키텍처, 심층 분석"></span></td><td>gpt-6-astra (high/xhigh)</td></tr>
         <tr><td style="color:var(--accent)"><span class="lang" data-en="Standard implementation" data-ko="표준 구현"></span></td><td>gpt-5.6-terra (medium)</td></tr>
         <tr><td style="color:var(--green)"><span class="lang" data-en="Quick lookup, exploration" data-ko="빠른 조회, 탐색"></span></td><td>gpt-5.6-luna (low)</td></tr>
       </table>
@@ -517,7 +517,7 @@ section{padding:80px 0}
     <div class="orig-card"><h4>Boss Meta-Orchestrator</h4><p><span class="lang" data-en="Runtime discovery, 5-phase delegation" data-ko="런타임 탐색, 5단계 위임"></span></p></div>
     <div class="orig-card"><h4>MD→TOML Pipeline</h4><p><span class="lang" data-en="Automated format conversion from upstream" data-ko="업스트림에서 자동 형식 변환"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Agent Tier Priority" data-ko="에이전트 계층 우선순위"></span></h4><p><span class="lang" data-en="Core > OMO > OMX > opt-in packs dedup resolution" data-ko="Core > OMO > OMX > 옵트인 팩 중복 해결"></span></p></div>
-    <div class="orig-card"><h4><span class="lang" data-en="Cost-Optimized Routing" data-ko="비용 최적화 라우팅"></span></h4><p><span class="lang" data-en="gpt-5.6-sol / gpt-5.6-terra / gpt-5.6-luna tier selection" data-ko="gpt-5.6-sol / gpt-5.6-terra / gpt-5.6-luna 티어 선택"></span></p></div>
+    <div class="orig-card"><h4><span class="lang" data-en="Cost-Optimized Routing" data-ko="비용 최적화 라우팅"></span></h4><p><span class="lang" data-en="gpt-6-astra / gpt-5.6-terra / gpt-5.6-luna tier selection" data-ko="gpt-6-astra / gpt-5.6-terra / gpt-5.6-luna 티어 선택"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Briefing Vault" data-ko="지식 금고"></span></h4><p><span class="lang" data-en="Obsidian-compatible project memory" data-ko="Obsidian 호환 프로젝트 메모리"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Agent Packs" data-ko="에이전트 팩"></span></h4><p><span class="lang" data-en="Opt-in domain specialist activation profiles" data-ko="옵트인 도메인 전문가 활성화 프로파일"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="3-Day Auto-Sync" data-ko="3일 주기 자동 동기화"></span></h4><p><span class="lang" data-en="Security-gated GitHub Actions upstream curation" data-ko="보안 게이트 GitHub Actions 업스트림 큐레이션"></span></p></div>

--- a/scripts/check-model-drift.sh
+++ b/scripts/check-model-drift.sh
@@ -24,7 +24,7 @@
 #   - .git/                        : object store.
 #   - scripts/model-tiers.sh       : single source of truth for model tiers; holds
 #                                    the legacy-model normalization mapping (old IDs
-#                                    gpt-5.4, gpt-5.3-codex-spark -> current tier)
+#                                    gpt-5.4, gpt-5.3-codex-spark, gpt-5.6-sol -> current tier)
 #                                    that install.sh and md-to-toml.sh source.
 #   - scripts/check-model-drift.sh : this file. Its own OLD_MODEL_PATTERN default
 #                                    literally contains the old IDs it hunts for
@@ -36,7 +36,7 @@ set -uo pipefail
 # Previous-generation model IDs. Overridable via env for local testing; CI
 # (smoke.yml) calls this script with no override, so this default is the
 # single source of truth — do not duplicate it elsewhere.
-OLD_MODEL_PATTERN="${OLD_MODEL_PATTERN:-gpt-5\.[0-5]([.-]|$| )|gpt-4|gpt-3|\bo1\b|\bo3\b|\bo4-mini\b|codex-spark}"
+OLD_MODEL_PATTERN="${OLD_MODEL_PATTERN:-gpt-5\.[0-5]([.-]|$| )|gpt-5\.6-sol|gpt-4|gpt-3|\bo1\b|\bo3\b|\bo4-mini\b|codex-spark}"
 
 # Path fragments to exclude from the scan (grep -E, matched against file path).
 EXCLUDE_PATHS="${EXCLUDE_PATHS:-(^|/)upstream/|(^|/)\.git/|(^|/)scripts/model-tiers\.sh$|(^|/)scripts/check-model-drift\.sh$}"

--- a/scripts/model-tiers.sh
+++ b/scripts/model-tiers.sh
@@ -10,14 +10,17 @@
 
 # Codex model ID per tier.
 #
-# Every value here MUST be a slug the Codex API actually serves. The 5.6
-# generation ships only suffixed slugs (sol/terra/luna) — a bare "gpt-5.6"
-# is NOT a real model and fails at request time with:
-#   400 invalid_request_error: The 'gpt-5.6' model is not supported when
+# Every value here MUST be a slug the Codex API actually serves. Generations
+# ship suffixed slugs only: 6 = "gpt-6-astra" (single slug so far), 5.6 =
+# sol/terra/luna. Bare "gpt-6" / "gpt-5.6" are NOT real models and fail at
+# request time with:
+#   400 invalid_request_error: The 'gpt-6' model is not supported when
 #   using Codex with a ChatGPT account.
 # Verify against `~/.codex/models_cache.json` (visibility="list") before
-# rolling these forward.
-MODEL_TIER_HIGH="gpt-5.6-sol"
+# rolling these forward. gpt-6-astra verified 2026-09-05 (efforts low..ultra;
+# high/xhigh probed OK). No gpt-6 mid/low slugs exist yet, so MEDIUM/LOW stay
+# on the 5.6 generation.
+MODEL_TIER_HIGH="gpt-6-astra"
 MODEL_TIER_MEDIUM="gpt-5.6-terra"
 MODEL_TIER_LOW="gpt-5.6-luna"
 
@@ -36,15 +39,17 @@ LEGACY_SPARK_MODEL="gpt-5.3-codex-spark"  # -> MODEL_TIER_LOW
 # where TIER is HIGH|MEDIUM|LOW, resolved against MODEL_TIER_* above.
 #
 # Two distinct classes live here:
-#   1. Superseded-but-still-served slugs (gpt-5.4, gpt-5.5) — promoted so the
-#      install tracks the current generation.
-#   2. Slugs that were never valid (bare gpt-5.6) — these HARD FAIL at request
-#      time, so rewriting them repairs installs made while that value shipped
-#      as MODEL_TIER_HIGH.
+#   1. Superseded-but-still-served slugs (gpt-5.4, gpt-5.5, gpt-5.6-sol) —
+#      promoted so the install tracks the current generation.
+#   2. Slugs that were never valid (bare gpt-5.6, bare gpt-6) — these HARD FAIL
+#      at request time, so rewriting them repairs installs made while that
+#      value shipped as MODEL_TIER_HIGH.
 LEGACY_MODEL_MAP=(
   "$LEGACY_WORKHORSE_MODEL:MEDIUM"
   "$LEGACY_SPARK_MODEL:LOW"
   "gpt-5.5:HIGH"
   "gpt-5.5-codex:HIGH"
   "gpt-5.6:HIGH"
+  "gpt-5.6-sol:HIGH"
+  "gpt-6:HIGH"
 )


### PR DESCRIPTION
## Why
GPT-6 Astra shipped 2026-09-04 ([OpenAI](https://openai.com/), [9to5Mac](https://9to5mac.com/2026/09/04/openai-releasing-major-upgrade-to-chatgpt-and-codex-with-gpt-6-astra-details-here/)). The refreshed `~/.codex/models_cache.json` lists `gpt-6-astra` (supported efforts low/medium/high/xhigh/max/ultra) as the only gpt-6 slug; bare `gpt-6` / `gpt-6-sol` return `400 not supported when using Codex with a ChatGPT account`.

## What
- `scripts/model-tiers.sh`: `MODEL_TIER_HIGH=gpt-6-astra` (MEDIUM/LOW unchanged — no gpt-6 mid/low slug exists yet); `LEGACY_MODEL_MAP` += `gpt-5.6-sol:HIGH`, `gpt-6:HIGH`.
- `scripts/check-model-drift.sh`: `gpt-5.6-sol` now counts as stale.
- 8 HIGH-tier agent TOMLs → `gpt-6-astra` (efforts unchanged).
- README / SETUP / CONTRIBUTING / Pages / i18n (ko, ja, zh, de, fr) updated; Boss/Oracle/Prometheus rows corrected to `xhigh` to match their TOMLs.

## Local verification
- `codex exec -m gpt-6-astra` with `model_reasoning_effort` high and xhigh → `ok`
- `check-model-drift.sh` → `OK: no stale model IDs in 94 scanned files; 27 agent model values all on-tier`
- `bash install.sh` from this tree → installed TOMLs: 12 × gpt-6-astra, 20 × gpt-5.6-terra, 2 × gpt-5.6-luna; `boss.toml` = gpt-6-astra / xhigh; 0 stale slugs under `~/.codex`
- Independent read-only review (consistency + regression, adversarially refuted): no blockers; one doc/TOML effort mismatch fixed in this PR.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p