### PR TITLE
feat(models): shift MEDIUM/LOW tiers to gpt-5.6-sol / gpt-5.6-terra

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,8 @@ developer_instructions = """
 
 | Field | Values | Notes |
 |-------|--------|-------|
-| `model` | `"gpt-6-astra"`, `"gpt-5.6-luna"` | Defaults to `gpt-6-astra` if omitted |
-| `model_reasoning_effort` | `"high"`, `"medium"`, `"low"` | Applies when model supports reasoning |
+| `model` | `"gpt-6-astra"`, `"gpt-5.6-sol"`, `"gpt-5.6-terra"` | HIGH / MEDIUM / LOW tier (see `scripts/model-tiers.sh`); omit to inherit the `~/.codex/config.toml` default |
+| `model_reasoning_effort` | `"xhigh"`, `"high"`, `"medium"`, `"low"` | Applies when model supports reasoning |
 | `sandbox_mode` | `"read-only"`, `"workspace-write"` | Use `read-only` for reviewers; `workspace-write` for implementers |
 | `nickname_candidates` | array of strings | Short invocation aliases |
 
@@ -68,8 +68,9 @@ developer_instructions = """
 
 | Model | Use For |
 |-------|---------|
-| `gpt-6-astra` | Standard development work, analysis, orchestration |
-| `gpt-5.6-luna` | Fast lookups, lightweight agents, frequent invocation |
+| `gpt-6-astra` | Architecture, deep analysis, orchestration (Boss, oracle, planner, reviewers) |
+| `gpt-5.6-sol` | Standard implementation, debugging, code review — the default worker tier |
+| `gpt-5.6-terra` | Fast lookups, lightweight agents, frequent invocation |
 
 **Sandbox mode guidance:**
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Boss cascades every request through a priority chain until the best match is fou
 | Complexity | Model | Used For |
 |-----------|-------|----------|
 | Deep analysis, architecture | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
-| Standard implementation | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
-| Quick lookup, exploration | gpt-5.6-luna (low) | explore, simple advisory |
+| Standard implementation | gpt-5.6-sol (medium) | executor, debugger, security-reviewer |
+| Quick lookup, exploration | gpt-5.6-terra (low) | explore, simple advisory |
 
 ### 3-Phase Sprint Workflow
 
@@ -213,8 +213,8 @@ It fires only at the very end of reasoning — never as a mid-task progress upda
 | Metis | gpt-6-astra high | Intent analysis, ambiguity detection | oh-my-openagent |
 | Momus | gpt-6-astra high | Plan feasibility review | oh-my-openagent |
 | Prometheus | gpt-6-astra xhigh | Interview-based detailed planning | oh-my-openagent |
-| Librarian | gpt-5.6-terra medium | Open-source documentation search via MCP | oh-my-openagent |
-| Multimodal-Looker | gpt-5.6-terra medium | Image/screenshot/diagram analysis | oh-my-openagent |
+| Librarian | gpt-5.6-sol medium | Open-source documentation search via MCP | oh-my-openagent |
+| Multimodal-Looker | gpt-5.6-sol medium | Image/screenshot/diagram analysis | oh-my-openagent |
 
 </details>
 
@@ -434,7 +434,7 @@ Features built specifically for this project, beyond what upstream sources provi
 | **Boss Meta-Orchestrator** | Dynamic capability discovery → intent classification → 4-priority routing → delegation → verification |
 | **3-Phase Sprint** | Design (interactive) → Execute (autonomous via executor) → Review (interactive vs design doc) |
 | **Agent Tier Priority** | core > omo > omx > opt-in packs. Pack agents are skipped if their name collides with an already-installed agent. Most specialized agent wins. |
-| **Cost Optimization** | gpt-5.6-luna for advisory, gpt-6-astra for implementation — automatic model routing across all 34 installed agents |
+| **Cost Optimization** | gpt-5.6-terra for lookups, gpt-5.6-sol for implementation, gpt-6-astra for architecture and review — automatic model routing across all 34 installed agents |
 | **Briefing Signals** | Wrapper/session logging feeds `.briefing/agents/agent-log.jsonl`, daily summaries, and routing/profile hints |
 | **Smart Packs** | Project-type detection recommends relevant agent packs at session start |
 | **Agent Pack System** | On-demand domain specialist activation via `--profile` and `my-codex-packs` helper |
@@ -490,7 +490,7 @@ Every agent is a native TOML file in `~/.codex/agents/`:
 ```toml
 name = "debugger"
 description = "Focused debugging specialist — traces failures to root cause"
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 
 [developer_instructions]
@@ -565,7 +565,7 @@ A GitHub Actions workflow runs every 3 days, pulling the latest commits from all
 <details>
 <summary><strong>What models does my-codex use?</strong></summary>
 
-Boss and sub-orchestrators (Sisyphus, Atlas, Oracle) use gpt-6-astra with high reasoning effort (Boss, Oracle, and Prometheus at xhigh). Standard workers use gpt-5.6-terra with medium reasoning. Lightweight advisory agents use gpt-5.6-luna.
+Boss and sub-orchestrators (Sisyphus, Atlas, Oracle) use gpt-6-astra with high reasoning effort (Boss, Oracle, and Prometheus at xhigh). Standard workers use gpt-5.6-sol with medium reasoning. Lightweight advisory agents use gpt-5.6-terra.
 
 Skills consume the SKILL.md standard as-is with no transformation; only agents are converted to Codex TOML, and the model tier for that conversion is managed from a single file, `scripts/model-tiers.sh`. When Codex ships its next model generation, update only that file — `scripts/md-to-toml.sh` and `install.sh` both source it.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -176,12 +176,12 @@ Codex CLI uses OpenAI reasoning models. Route tasks by complexity:
 | Model | Reasoning Effort | Use For |
 |---|---|---|
 | gpt-6-astra (high) | Deep | Architecture, complex analysis, security review |
-| gpt-5.6-terra (medium) | Standard | Implementation, code review, debugging |
-| gpt-5.6-luna (low) | Fast | Quick lookups, exploration, trivial changes |
+| gpt-5.6-sol (medium) | Standard | Implementation, code review, debugging |
+| gpt-5.6-terra (low) | Fast | Quick lookups, exploration, trivial changes |
 
 Set default model in `~/.codex/config.toml`:
 ```toml
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 multi_agent = true
 ```

--- a/codex-agents/omo/librarian.toml
+++ b/codex-agents/omo/librarian.toml
@@ -1,6 +1,6 @@
 name = "librarian"
 description = "Use when a question about an open-source library must be answered from its real source or docs, not memory; returns the answer with GitHub permalinks to the exact lines."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/omo/multimodal-looker.toml
+++ b/codex-agents/omo/multimodal-looker.toml
@@ -1,6 +1,6 @@
 name = "multimodal-looker"
 description = "Use when answering requires looking at a media file — image, PDF, diagram, or screenshot — that cannot be read as plain text; returns only the requested extraction from that file. Read-only."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/ai-engineer.toml
+++ b/codex-agents/packs/data-ai/ai-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "ai-engineer"
 description = "Use when a task needs implementation or debugging of model-backed application features, agent flows, or evaluation hooks."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/data-analyst.toml
+++ b/codex-agents/packs/data-ai/data-analyst.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "data-analyst"
 description = "Use when a task needs data interpretation, metric breakdown, trend explanation, or decision support from existing analytics outputs."
-model = "gpt-5.6-luna"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/data-engineer.toml
+++ b/codex-agents/packs/data-ai/data-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "data-engineer"
 description = "Use when a task needs ETL, ingestion, transformation, warehouse, or data-pipeline implementation and debugging."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/data-scientist.toml
+++ b/codex-agents/packs/data-ai/data-scientist.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "data-scientist"
 description = "Use when a task needs statistical reasoning, experiment interpretation, feature analysis, or model-oriented data exploration."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/database-optimizer.toml
+++ b/codex-agents/packs/data-ai/database-optimizer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "database-optimizer"
 description = "Use when a task needs database performance analysis for query plans, schema design, indexing, or data access patterns."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/llm-architect.toml
+++ b/codex-agents/packs/data-ai/llm-architect.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "llm-architect"
 description = "Use when a task needs architecture review for prompts, tool use, retrieval, evaluation, or multi-step LLM workflows."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/machine-learning-engineer.toml
+++ b/codex-agents/packs/data-ai/machine-learning-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "machine-learning-engineer"
 description = "Use when a task needs ML system implementation work across training pipelines, feature flow, model serving, or inference integration."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/ml-engineer.toml
+++ b/codex-agents/packs/data-ai/ml-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "ml-engineer"
 description = "Use when a task needs practical machine learning implementation across feature engineering, inference wiring, and model-backed application logic."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/mlops-engineer.toml
+++ b/codex-agents/packs/data-ai/mlops-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "mlops-engineer"
 description = "Use when a task needs model deployment, registry, pipeline, monitoring, or environment orchestration for machine learning systems."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/nlp-engineer.toml
+++ b/codex-agents/packs/data-ai/nlp-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "nlp-engineer"
 description = "Use when a task needs NLP-specific implementation or analysis involving text processing, embeddings, ranking, or language-model-adjacent pipelines."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/postgres-pro.toml
+++ b/codex-agents/packs/data-ai/postgres-pro.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "postgres-pro"
 description = "Use when a task needs PostgreSQL-specific expertise for schema design, performance behavior, locking, or operational database features."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/prompt-engineer.toml
+++ b/codex-agents/packs/data-ai/prompt-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "prompt-engineer"
 description = "Use when a task needs prompt revision, instruction design, eval-oriented prompt comparison, or prompt-output contract tightening."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/data-ai/reinforcement-learning-engineer.toml
+++ b/codex-agents/packs/data-ai/reinforcement-learning-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "reinforcement-learning-engineer"
 description = "Use when a task needs RL environment design, policy training, reward engineering, or deployment of decision-making agents."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/codex-agents/packs/llmops/ai-observability-engineer.toml
+++ b/codex-agents/packs/llmops/ai-observability-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "ai-observability-engineer"
 description = "Use when a task needs AI-native traces, metrics, logging, and debugging signals for LLM or agent systems in production."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/llmops/eval-engineer.toml
+++ b/codex-agents/packs/llmops/eval-engineer.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "eval-engineer"
 description = "Use when a task needs evaluation design for prompts, retrieval, tools, or multi-step agent workflows."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/llmops/hallucination-investigator.toml
+++ b/codex-agents/packs/llmops/hallucination-investigator.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "hallucination-investigator"
 description = "Use when a task needs root-cause analysis for factuality failures, unsupported claims, or context breakdowns in AI outputs."
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/codex-agents/packs/llmops/prompt-regression-tester.toml
+++ b/codex-agents/packs/llmops/prompt-regression-tester.toml
@@ -1,7 +1,7 @@
 # Vendored from https://github.com/VoltAgent/awesome-codex-subagents (MIT License). Snapshot: 2026-07-27 (model IDs normalized to current tier).
 name = "prompt-regression-tester"
 description = "Use when a task needs regression coverage for prompt, model, tool, or workflow changes in an AI system."
-model = "gpt-5.6-luna"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -105,8 +105,8 @@ Boss leitet jede Anfrage durch eine Prioritätskette, bis die beste Übereinstim
 | Komplexität | Modell | Verwendet für |
 |-------------|--------|---------------|
 | Tiefgehende Analyse, Architektur | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
-| Standardimplementierung | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
-| Schnelle Suche, Erkundung | gpt-5.6-luna (low) | explore, einfache Beratung |
+| Standardimplementierung | gpt-5.6-sol (medium) | executor, debugger, security-reviewer |
+| Schnelle Suche, Erkundung | gpt-5.6-terra (low) | explore, einfache Beratung |
 
 ### 3-Phasen-Sprint-Workflow
 
@@ -204,8 +204,8 @@ Er wird nur ganz am Ende des Reasonings ausgelöst — niemals als Fortschrittsm
 | Metis | gpt-6-astra high | Absichtsanalyse, Mehrdeutigkeitserkennung | oh-my-openagent |
 | Momus | gpt-6-astra high | Überprüfung der Planumsetzbarkeit | oh-my-openagent |
 | Prometheus | gpt-6-astra xhigh | Interviewbasierte detaillierte Planung | oh-my-openagent |
-| Librarian | gpt-5.6-terra medium | Open-Source-Dokumentationssuche über MCP | oh-my-openagent |
-| Multimodal-Looker | gpt-5.6-terra medium | Bild-/Screenshot-/Diagrammanalyse | oh-my-openagent |
+| Librarian | gpt-5.6-sol medium | Open-Source-Dokumentationssuche über MCP | oh-my-openagent |
+| Multimodal-Looker | gpt-5.6-sol medium | Bild-/Screenshot-/Diagrammanalyse | oh-my-openagent |
 
 </details>
 
@@ -406,7 +406,7 @@ Funktionen, die speziell für dieses Projekt entwickelt wurden und über das hin
 | **Boss Meta-Orchestrator** | Dynamische Fähigkeitsentdeckung → Absichtsklassifizierung → 4-Prioritäten-Routing → Delegation → Verifikation |
 | **3-Phasen-Sprint** | Design (interaktiv) → Ausführung (autonom über executor) → Review (interaktiv vs. Design-Dokument) |
 | **Agenten-Tier-Priorität** | core > omo > omx > Opt-in-Packs. Pack-Agenten mit Namenskollision zu einem bereits installierten Agenten werden übersprungen. Der speziellste Agent gewinnt. |
-| **Kostenoptimierung** | gpt-5.6-luna für Beratung, gpt-6-astra für Implementierung — automatisches Modell-Routing über alle 34 installierten Agenten |
+| **Kostenoptimierung** | gpt-5.6-terra für Nachschlagen, gpt-5.6-sol für Implementierung, gpt-6-astra für Architektur und Review — automatisches Modell-Routing über alle 34 installierten Agenten |
 | **Agenten-Telemetrie** | PostToolUse-Hook protokolliert Agentennutzung in `agent-usage.jsonl` |
 | **Smart Packs** | Projekttypenerkennung empfiehlt relevante Agenten-Packs beim Sitzungsstart |
 | **Agenten-Pack-System** | On-demand-Domänenspezialisten-Aktivierung über `--profile` und `my-codex-packs`-Hilfsprogramm |
@@ -462,7 +462,7 @@ Jeder Agent ist eine native TOML-Datei in `~/.codex/agents/`:
 ```toml
 name = "debugger"
 description = "Focused debugging specialist — traces failures to root cause"
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 
 [developer_instructions]
@@ -537,7 +537,7 @@ Ein GitHub Actions-Workflow läuft alle 3 Tage, zieht die neuesten Commits aus a
 <details>
 <summary><strong>Welche Modelle verwendet my-codex?</strong></summary>
 
-Boss und Sub-Orchestratoren (Sisyphus, Atlas, Oracle) verwenden gpt-6-astra mit hohem Reasoning-Aufwand. Standard-Worker verwenden gpt-5.6-terra mit mittlerem Reasoning. Leichtgewichtige Beratungsagenten verwenden gpt-5.6-luna.
+Boss und Sub-Orchestratoren (Sisyphus, Atlas, Oracle) verwenden gpt-6-astra mit hohem Reasoning-Aufwand. Standard-Worker verwenden gpt-5.6-sol mit mittlerem Reasoning. Leichtgewichtige Beratungsagenten verwenden gpt-5.6-terra.
 
 </details>
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -109,8 +109,8 @@ Boss cascade chaque requête dans une chaîne de priorités jusqu'à trouver la 
 | Complexité | Modèle | Utilisé pour |
 |-----------|-------|----------|
 | Analyse approfondie, architecture | gpt-6-astra (raisonnement high/xhigh) | Boss, Oracle, Sisyphus, Atlas |
-| Implémentation standard | gpt-5.6-terra (moyen) | executor, debugger, security-reviewer |
-| Recherche rapide, exploration | gpt-5.6-luna (faible) | explore, conseil simple |
+| Implémentation standard | gpt-5.6-sol (moyen) | executor, debugger, security-reviewer |
+| Recherche rapide, exploration | gpt-5.6-terra (faible) | explore, conseil simple |
 
 ### Workflow en sprint 3 phases
 
@@ -214,8 +214,8 @@ Il ne se déclenche qu'à la toute fin du raisonnement — jamais comme point d'
 | Metis | gpt-6-astra high | Analyse d'intention, détection d'ambiguïté | oh-my-openagent |
 | Momus | gpt-6-astra high | Révision de faisabilité des plans | oh-my-openagent |
 | Prometheus | gpt-6-astra xhigh | Planification détaillée par entretien | oh-my-openagent |
-| Librarian | gpt-5.6-terra medium | Recherche de documentation open source via MCP | oh-my-openagent |
-| Multimodal-Looker | gpt-5.6-terra medium | Analyse d'images, captures d'écran et diagrammes | oh-my-openagent |
+| Librarian | gpt-5.6-sol medium | Recherche de documentation open source via MCP | oh-my-openagent |
+| Multimodal-Looker | gpt-5.6-sol medium | Analyse d'images, captures d'écran et diagrammes | oh-my-openagent |
 
 </details>
 
@@ -416,7 +416,7 @@ Fonctionnalités construites spécifiquement pour ce projet, au-delà de ce que 
 | **Boss Méta-Orchestrateur** | Découverte dynamique des capacités → classification d'intention → routage à 4 priorités → délégation → vérification |
 | **Sprint 3 phases** | Conception (interactive) → Exécution (autonome via executor) → Révision (interactive vs doc de conception) |
 | **Priorité par niveau d'agent** | core > omo > omx > packs optionnels. Un agent de pack dont le nom entre en collision avec un agent déjà installé est ignoré. L'agent le plus spécialisé l'emporte. |
-| **Optimisation des coûts** | gpt-5.6-luna pour le conseil, gpt-6-astra pour l'implémentation — routage de modèle automatique sur les 34 agents installés |
+| **Optimisation des coûts** | gpt-5.6-terra pour les recherches, gpt-5.6-sol pour l'implémentation, gpt-6-astra pour l'architecture et la revue — routage de modèle automatique sur les 34 agents installés |
 | **Télémétrie des agents** | Le hook PostToolUse enregistre l'utilisation des agents dans `agent-usage.jsonl` |
 | **Smart Packs** | La détection du type de projet recommande les packs d'agents pertinents au démarrage de session |
 | **Système de packs d'agents** | Activation de spécialistes de domaine à la demande via `--profile` et l'aide `my-codex-packs` |
@@ -472,7 +472,7 @@ Chaque agent est un fichier TOML natif dans `~/.codex/agents/` :
 ```toml
 name = "debugger"
 description = "Focused debugging specialist — traces failures to root cause"
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 
 [developer_instructions]
@@ -547,7 +547,7 @@ Un workflow GitHub Actions s'exécute tous les 3 jours, récupérant les dernier
 <details>
 <summary><strong>Quels modèles utilise my-codex ?</strong></summary>
 
-Boss et les sous-orchestrateurs (Sisyphus, Atlas, Oracle) utilisent gpt-6-astra avec un niveau de raisonnement élevé. Les agents de travail standard utilisent gpt-5.6-terra avec un raisonnement moyen. Les agents de conseil légers utilisent gpt-5.6-luna.
+Boss et les sous-orchestrateurs (Sisyphus, Atlas, Oracle) utilisent gpt-6-astra avec un niveau de raisonnement élevé. Les agents de travail standard utilisent gpt-5.6-sol avec un raisonnement moyen. Les agents de conseil légers utilisent gpt-5.6-terra.
 
 </details>
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -105,8 +105,8 @@ Boss はすべてのリクエストを優先チェーンにカスケードし、
 | 複雑度 | モデル | 使用場面 |
 |-----------|-------|----------|
 | 深い分析、アーキテクチャ | gpt-6-astra (high/xhigh reasoning) | Boss、Oracle、Sisyphus、Atlas |
-| 標準的な実装 | gpt-5.6-terra (medium) | executor、debugger、security-reviewer |
-| 簡単な検索、調査 | gpt-5.6-luna (low) | explore、簡易アドバイザリー |
+| 標準的な実装 | gpt-5.6-sol (medium) | executor、debugger、security-reviewer |
+| 簡単な検索、調査 | gpt-5.6-terra (low) | explore、簡易アドバイザリー |
 
 ### 3 フェーズスプリントワークフロー
 
@@ -204,8 +204,8 @@ Boss は作業が発生したすべてのターン — ファイルの編集・�
 | Metis | gpt-6-astra high | インテント分析、曖昧さ検出 | oh-my-openagent |
 | Momus | gpt-6-astra high | 計画実現可能性レビュー | oh-my-openagent |
 | Prometheus | gpt-6-astra xhigh | インタビューベースの詳細計画立案 | oh-my-openagent |
-| Librarian | gpt-5.6-terra medium | MCP 経由のオープンソースドキュメント検索 | oh-my-openagent |
-| Multimodal-Looker | gpt-5.6-terra medium | 画像・スクリーンショット・図の分析 | oh-my-openagent |
+| Librarian | gpt-5.6-sol medium | MCP 経由のオープンソースドキュメント検索 | oh-my-openagent |
+| Multimodal-Looker | gpt-5.6-sol medium | 画像・スクリーンショット・図の分析 | oh-my-openagent |
 
 </details>
 
@@ -406,7 +406,7 @@ my-codex は **4 つのアップストリームサブモジュール**に加え�
 | **Boss メタオーケストレーター** | ダイナミックケイパビリティ検出 → インテント分類 → 4 優先ルーティング → 委任 → 検証 |
 | **3 フェーズスプリント** | 設計（インタラクティブ）→ 実行（executor による自律）→ レビュー（設計書との比較インタラクティブ） |
 | **エージェント層優先度** | core > omo > omx > オプトインパックの順で重複排除。既存エージェントと名前が衝突するパックエージェントはスキップ。最も特化したエージェントが優先。 |
-| **コスト最適化** | アドバイザリーには gpt-5.6-luna、実装には gpt-6-astra — インストール済み 34 エージェント全体への自動モデルルーティング |
+| **コスト最適化** | 参照には gpt-5.6-terra、実装には gpt-5.6-sol、アーキテクチャとレビューには gpt-6-astra — インストール済み 34 エージェント全体への自動モデルルーティング |
 | **エージェントテレメトリー** | PostToolUse フックがエージェント使用状況を `agent-usage.jsonl` に記録 |
 | **スマートパック** | プロジェクトタイプ検出がセッション開始時に関連エージェントパックを推奨 |
 | **エージェントパックシステム** | `--profile` と `my-codex-packs` ヘルパーによるオンデマンドのドメインスペシャリスト有効化 |
@@ -462,7 +462,7 @@ bash /tmp/my-codex/install.sh --profile full
 ```toml
 name = "debugger"
 description = "Focused debugging specialist — traces failures to root cause"
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 
 [developer_instructions]
@@ -537,7 +537,7 @@ GitHub Actions ワークフローが 3 日ごとに実行され、4 つのアッ
 <details>
 <summary><strong>my-codex が使用するモデルは何ですか？</strong></summary>
 
-Boss とサブオーケストレーター（Sisyphus、Atlas、Oracle）は高い推論努力で gpt-6-astra を使用します。標準ワーカーは中程度の推論で gpt-5.6-terra を使用します。軽量アドバイザリーエージェントは gpt-5.6-luna を使用します。
+Boss とサブオーケストレーター（Sisyphus、Atlas、Oracle）は高い推論努力で gpt-6-astra を使用します。標準ワーカーは中程度の推論で gpt-5.6-sol を使用します。軽量アドバイザリーエージェントは gpt-5.6-terra を使用します。
 
 </details>
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -105,8 +105,8 @@ Boss는 가장 적합한 매칭을 찾을 때까지 모든 요청을 우선순�
 | 복잡도 | 모델 | 사용 대상 |
 |-----------|-------|----------|
 | 심층 분석, 아키텍처 | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
-| 표준 구현 | gpt-5.6-terra (medium) | executor, debugger, security-reviewer |
-| 빠른 조회, 탐색 | gpt-5.6-luna (low) | explore, 간단한 자문 |
+| 표준 구현 | gpt-5.6-sol (medium) | executor, debugger, security-reviewer |
+| 빠른 조회, 탐색 | gpt-5.6-terra (low) | explore, 간단한 자문 |
 
 ### 3단계 스프린트 워크플로
 
@@ -204,8 +204,8 @@ Boss는 작업이 있던 모든 턴 — 파일 편집·생성, 커밋/PR/머지,
 | Metis | gpt-6-astra high | 의도 분석, 모호성 탐지 | oh-my-openagent |
 | Momus | gpt-6-astra high | 계획 실현 가능성 검토 | oh-my-openagent |
 | Prometheus | gpt-6-astra xhigh | 인터뷰 기반 세부 계획 수립 | oh-my-openagent |
-| Librarian | gpt-5.6-terra medium | MCP를 통한 오픈소스 문서 검색 | oh-my-openagent |
-| Multimodal-Looker | gpt-5.6-terra medium | 이미지/스크린샷/다이어그램 분석 | oh-my-openagent |
+| Librarian | gpt-5.6-sol medium | MCP를 통한 오픈소스 문서 검색 | oh-my-openagent |
+| Multimodal-Looker | gpt-5.6-sol medium | 이미지/스크린샷/다이어그램 분석 | oh-my-openagent |
 
 </details>
 
@@ -406,7 +406,7 @@ my-codex는 **4개의 업스트림 서브모듈**과 벤더링된 스냅샷 1개
 | **Boss 메타 오케스트레이터** | 동적 역량 탐색 → 의도 분류 → 4단계 우선순위 라우팅 → 위임 → 검증 |
 | **3단계 스프린트** | 설계 (대화형) → 실행 (executor를 통한 자율) → 리뷰 (설계 문서와 대화형 비교) |
 | **에이전트 티어 우선순위** | core > omo > omx > 옵트인 팩 순으로 중복 제거. 이미 설치된 에이전트와 이름이 겹치는 팩 에이전트는 건너뜁니다. 가장 특화된 에이전트가 선택됩니다. |
-| **비용 최적화** | 자문에는 gpt-5.6-luna, 구현에는 gpt-6-astra — 설치된 34개 에이전트 전체에 대한 자동 모델 라우팅 |
+| **비용 최적화** | 조회에는 gpt-5.6-terra, 구현에는 gpt-5.6-sol, 아키텍처·리뷰에는 gpt-6-astra — 설치된 34개 에이전트 전체에 대한 자동 모델 라우팅 |
 | **에이전트 텔레메트리** | PostToolUse 훅이 에이전트 사용량을 `agent-usage.jsonl`에 기록 |
 | **Smart Packs** | 프로젝트 유형 감지로 세션 시작 시 관련 에이전트 팩 추천 |
 | **에이전트 팩 시스템** | `--profile` 및 `my-codex-packs` 헬퍼를 통한 온디맨드 도메인 전문가 활성화 |
@@ -462,7 +462,7 @@ bash /tmp/my-codex/install.sh --profile full
 ```toml
 name = "debugger"
 description = "Focused debugging specialist — traces failures to root cause"
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 
 [developer_instructions]
@@ -537,7 +537,7 @@ GitHub Actions 워크플로가 3일마다 실행되어 4개 업스트림 서브�
 <details>
 <summary><strong>my-codex는 어떤 모델을 사용하나요?</strong></summary>
 
-Boss와 서브 오케스트레이터(Sisyphus, Atlas, Oracle)는 high reasoning effort의 gpt-6-astra를 사용합니다. 표준 작업자는 medium reasoning의 gpt-5.6-terra를 사용합니다. 경량 자문 에이전트는 gpt-5.6-luna를 사용합니다.
+Boss와 서브 오케스트레이터(Sisyphus, Atlas, Oracle)는 high reasoning effort의 gpt-6-astra를 사용합니다. 표준 작업자는 medium reasoning의 gpt-5.6-sol을 사용합니다. 경량 자문 에이전트는 gpt-5.6-terra를 사용합니다.
 
 </details>
 

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -105,8 +105,8 @@ Boss 对每个请求按优先级链逐级匹配，直到找到最佳方案：
 | 复杂度 | 模型 | 用途 |
 |-----------|-------|----------|
 | 深度分析、架构 | gpt-6-astra （high/xhigh reasoning） | Boss、Oracle、Sisyphus、Atlas |
-| 标准实现 | gpt-5.6-terra（medium） | executor、debugger、security-reviewer |
-| 快速查询、探索 | gpt-5.6-luna（low） | explore、简单咨询 |
+| 标准实现 | gpt-5.6-sol（medium） | executor、debugger、security-reviewer |
+| 快速查询、探索 | gpt-5.6-terra（low） | explore、简单咨询 |
 
 ### 三阶段冲刺工作流
 
@@ -204,8 +204,8 @@ Boss 会以一份无需打开 diff 即可浏览的结构化最终报告来结束
 | Metis | gpt-6-astra high | 意图分析、歧义检测 | oh-my-openagent |
 | Momus | gpt-6-astra high | 计划可行性评审 | oh-my-openagent |
 | Prometheus | gpt-6-astra xhigh | 基于访谈的详细规划 | oh-my-openagent |
-| Librarian | gpt-5.6-terra medium | 通过 MCP 搜索开源文档 | oh-my-openagent |
-| Multimodal-Looker | gpt-5.6-terra medium | 图像 / 截图 / 图表分析 | oh-my-openagent |
+| Librarian | gpt-5.6-sol medium | 通过 MCP 搜索开源文档 | oh-my-openagent |
+| Multimodal-Looker | gpt-5.6-sol medium | 图像 / 截图 / 图表分析 | oh-my-openagent |
 
 </details>
 
@@ -406,7 +406,7 @@ my-codex 由 **4 个上游子模块**，加上 1 份内置快照、2 个适配/�
 | **Boss 元编排器** | 动态能力发现 → 意图分类 → 4 级优先路由 → 委派 → 验证 |
 | **三阶段冲刺** | 设计（交互式）→ 执行（通过 executor 自主进行）→ 审查（交互式对比设计文档） |
 | **Agent 层级优先级** | core > omo > omx > 可选包 依次去重。与已安装 Agent 同名的包内 Agent 会被跳过。最专业的 Agent 优先。 |
-| **成本优化** | 咨询用 gpt-5.6-luna，实现用 gpt-6-astra——覆盖全部 34 个已安装 Agent 的自动模型路由 |
+| **成本优化** | 查询用 gpt-5.6-terra，实现用 gpt-5.6-sol，架构与评审用 gpt-6-astra——覆盖全部 34 个已安装 Agent 的自动模型路由 |
 | **Agent 遥测** | PostToolUse hook 将 Agent 使用情况记录到 `agent-usage.jsonl` |
 | **智能包** | 项目类型检测在会话开始时推荐相关 Agent 包 |
 | **Agent 包系统** | 通过 `--profile` 和 `my-codex-packs` 助手按需激活领域专家 |
@@ -462,7 +462,7 @@ bash /tmp/my-codex/install.sh --profile full
 ```toml
 name = "debugger"
 description = "Focused debugging specialist — traces failures to root cause"
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 
 [developer_instructions]
@@ -537,7 +537,7 @@ GitHub Actions 工作流每 3 天运行一次，从 4 个上游子模块拉取�
 <details>
 <summary><strong>my-codex 使用哪些模型？</strong></summary>
 
-Boss 和子编排器（Sisyphus、Atlas、Oracle）使用 gpt-6-astra 高推理强度。标准工作者使用 gpt-5.6-terra 中等推理强度。轻量级咨询 Agent 使用 gpt-5.6-luna。
+Boss 和子编排器（Sisyphus、Atlas、Oracle）使用 gpt-6-astra 高推理强度。标准工作者使用 gpt-5.6-sol 中等推理强度。轻量级咨询 Agent 使用 gpt-5.6-terra。
 
 </details>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -288,8 +288,8 @@ section{padding:80px 0}
       <table class="route-table">
         <tr><th><span class="lang" data-en="Complexity" data-ko="복잡도"></span></th><th><span class="lang" data-en="Model" data-ko="모델"></span></th></tr>
         <tr><td style="color:var(--primary)"><span class="lang" data-en="Architecture, deep analysis" data-ko="아키텍처, 심층 분석"></span></td><td>gpt-6-astra (high/xhigh)</td></tr>
-        <tr><td style="color:var(--accent)"><span class="lang" data-en="Standard implementation" data-ko="표준 구현"></span></td><td>gpt-5.6-terra (medium)</td></tr>
-        <tr><td style="color:var(--green)"><span class="lang" data-en="Quick lookup, exploration" data-ko="빠른 조회, 탐색"></span></td><td>gpt-5.6-luna (low)</td></tr>
+        <tr><td style="color:var(--accent)"><span class="lang" data-en="Standard implementation" data-ko="표준 구현"></span></td><td>gpt-5.6-sol (medium)</td></tr>
+        <tr><td style="color:var(--green)"><span class="lang" data-en="Quick lookup, exploration" data-ko="빠른 조회, 탐색"></span></td><td>gpt-5.6-terra (low)</td></tr>
       </table>
     </div>
   </div>
@@ -517,7 +517,7 @@ section{padding:80px 0}
     <div class="orig-card"><h4>Boss Meta-Orchestrator</h4><p><span class="lang" data-en="Runtime discovery, 5-phase delegation" data-ko="런타임 탐색, 5단계 위임"></span></p></div>
     <div class="orig-card"><h4>MD→TOML Pipeline</h4><p><span class="lang" data-en="Automated format conversion from upstream" data-ko="업스트림에서 자동 형식 변환"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Agent Tier Priority" data-ko="에이전트 계층 우선순위"></span></h4><p><span class="lang" data-en="Core > OMO > OMX > opt-in packs dedup resolution" data-ko="Core > OMO > OMX > 옵트인 팩 중복 해결"></span></p></div>
-    <div class="orig-card"><h4><span class="lang" data-en="Cost-Optimized Routing" data-ko="비용 최적화 라우팅"></span></h4><p><span class="lang" data-en="gpt-6-astra / gpt-5.6-terra / gpt-5.6-luna tier selection" data-ko="gpt-6-astra / gpt-5.6-terra / gpt-5.6-luna 티어 선택"></span></p></div>
+    <div class="orig-card"><h4><span class="lang" data-en="Cost-Optimized Routing" data-ko="비용 최적화 라우팅"></span></h4><p><span class="lang" data-en="gpt-6-astra / gpt-5.6-sol / gpt-5.6-terra tier selection" data-ko="gpt-6-astra / gpt-5.6-sol / gpt-5.6-terra 티어 선택"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Briefing Vault" data-ko="지식 금고"></span></h4><p><span class="lang" data-en="Obsidian-compatible project memory" data-ko="Obsidian 호환 프로젝트 메모리"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="Agent Packs" data-ko="에이전트 팩"></span></h4><p><span class="lang" data-en="Opt-in domain specialist activation profiles" data-ko="옵트인 도메인 전문가 활성화 프로파일"></span></p></div>
     <div class="orig-card"><h4><span class="lang" data-en="3-Day Auto-Sync" data-ko="3일 주기 자동 동기화"></span></h4><p><span class="lang" data-en="Security-gated GitHub Actions upstream curation" data-ko="보안 게이트 GitHub Actions 업스트림 큐레이션"></span></p></div>

--- a/scripts/check-model-drift.sh
+++ b/scripts/check-model-drift.sh
@@ -24,7 +24,7 @@
 #   - .git/                        : object store.
 #   - scripts/model-tiers.sh       : single source of truth for model tiers; holds
 #                                    the legacy-model normalization mapping (old IDs
-#                                    gpt-5.4, gpt-5.3-codex-spark, gpt-5.6-sol -> current tier)
+#                                    gpt-5.4, gpt-5.3-codex-spark, gpt-5.6-luna -> current tier)
 #                                    that install.sh and md-to-toml.sh source.
 #   - scripts/check-model-drift.sh : this file. Its own OLD_MODEL_PATTERN default
 #                                    literally contains the old IDs it hunts for
@@ -36,7 +36,7 @@ set -uo pipefail
 # Previous-generation model IDs. Overridable via env for local testing; CI
 # (smoke.yml) calls this script with no override, so this default is the
 # single source of truth — do not duplicate it elsewhere.
-OLD_MODEL_PATTERN="${OLD_MODEL_PATTERN:-gpt-5\.[0-5]([.-]|$| )|gpt-5\.6-sol|gpt-4|gpt-3|\bo1\b|\bo3\b|\bo4-mini\b|codex-spark}"
+OLD_MODEL_PATTERN="${OLD_MODEL_PATTERN:-gpt-5\.[0-5]([.-]|$| )|gpt-5\.6-luna|gpt-4|gpt-3|\bo1\b|\bo3\b|\bo4-mini\b|codex-spark}"
 
 # Path fragments to exclude from the scan (grep -E, matched against file path).
 EXCLUDE_PATHS="${EXCLUDE_PATHS:-(^|/)upstream/|(^|/)\.git/|(^|/)scripts/model-tiers\.sh$|(^|/)scripts/check-model-drift\.sh$}"

--- a/scripts/model-tiers.sh
+++ b/scripts/model-tiers.sh
@@ -18,11 +18,12 @@
 #   using Codex with a ChatGPT account.
 # Verify against `~/.codex/models_cache.json` (visibility="list") before
 # rolling these forward. gpt-6-astra verified 2026-09-05 (efforts low..ultra;
-# high/xhigh probed OK). No gpt-6 mid/low slugs exist yet, so MEDIUM/LOW stay
-# on the 5.6 generation.
+# high/xhigh probed OK). No gpt-6 mid/low slugs exist yet, so MEDIUM/LOW use
+# the top two 5.6 slugs: sol ("reliable agentic workhorse for everyday tasks")
+# and terra ("balanced agentic coding model"). luna is retired from the tiers.
 MODEL_TIER_HIGH="gpt-6-astra"
-MODEL_TIER_MEDIUM="gpt-5.6-terra"
-MODEL_TIER_LOW="gpt-5.6-luna"
+MODEL_TIER_MEDIUM="gpt-5.6-sol"
+MODEL_TIER_LOW="gpt-5.6-terra"
 
 # model_reasoning_effort per tier.
 MODEL_TIER_HIGH_EFFORT="high"
@@ -39,8 +40,8 @@ LEGACY_SPARK_MODEL="gpt-5.3-codex-spark"  # -> MODEL_TIER_LOW
 # where TIER is HIGH|MEDIUM|LOW, resolved against MODEL_TIER_* above.
 #
 # Two distinct classes live here:
-#   1. Superseded-but-still-served slugs (gpt-5.4, gpt-5.5, gpt-5.6-sol) —
-#      promoted so the install tracks the current generation.
+#   1. Superseded-but-still-served slugs (gpt-5.4, gpt-5.5, gpt-5.6-luna) —
+#      promoted so the install tracks the current tiers.
 #   2. Slugs that were never valid (bare gpt-5.6, bare gpt-6) — these HARD FAIL
 #      at request time, so rewriting them repairs installs made while that
 #      value shipped as MODEL_TIER_HIGH.
@@ -50,6 +51,6 @@ LEGACY_MODEL_MAP=(
   "gpt-5.5:HIGH"
   "gpt-5.5-codex:HIGH"
   "gpt-5.6:HIGH"
-  "gpt-5.6-sol:HIGH"
+  "gpt-5.6-luna:LOW"
   "gpt-6:HIGH"
 )


### PR DESCRIPTION
## Why
With `gpt-6-astra` as HIGH (#78), the next two Codex slugs by cache priority are `gpt-5.6-sol` (p6, "reliable agentic workhorse for everyday tasks") and `gpt-5.6-terra` (p7, "balanced agentic coding model"). Each tier moves up one model; `gpt-5.6-luna` retires from the tiers.

## What
| Tier | Before | After |
|---|---|---|
| HIGH | gpt-6-astra | gpt-6-astra |
| MEDIUM | gpt-5.6-terra | **gpt-5.6-sol** |
| LOW | gpt-5.6-luna | **gpt-5.6-terra** |

- `scripts/model-tiers.sh` values + `LEGACY_MODEL_MAP` (−`gpt-5.6-sol:HIGH`, +`gpt-5.6-luna:LOW`); `check-model-drift.sh` stale pattern (+luna, −sol)
- 19 agent TOMLs (17 terra→sol, 2 luna→terra), efforts unchanged
- README / SETUP / CONTRIBUTING (3-tier model table) / Pages / i18n ko·ja·zh·de·fr

## Local verification
- `check-model-drift.sh` → OK (94 files, 27 agents on-tier)
- `bash install.sh` from this tree → installed TOMLs 12 astra / 20 sol / 2 terra, 0 stale
- `codex exec -m gpt-5.6-sol` / `-m gpt-5.6-terra` → ok
- Independent read-only review (consistency + regression, refuted adversarially): no blockers; the one fix (CONTRIBUTING model table) is included

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p