### PR TITLE
chore(models): resolve tier-review nits (docs + comments only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Boss cascades every request through a priority chain until the best match is fou
 | Complexity | Model | Used For |
 |-----------|-------|----------|
 | Deep analysis, architecture | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
-| Standard implementation | gpt-5.6-sol (medium) | executor, debugger, security-reviewer |
+| Standard implementation | gpt-5.6-sol (medium) | executor, debugger, test-engineer |
 | Quick lookup, exploration | gpt-5.6-terra (low) | explore, simple advisory |
 
 ### 3-Phase Sprint Workflow

--- a/SETUP.md
+++ b/SETUP.md
@@ -177,7 +177,7 @@ Codex CLI uses OpenAI reasoning models. Route tasks by complexity:
 |---|---|---|
 | gpt-6-astra (high) | Deep | Architecture, complex analysis, security review |
 | gpt-5.6-sol (medium) | Standard | Implementation, code review, debugging |
-| gpt-5.6-terra (low) | Fast | Quick lookups, exploration, trivial changes |
+| gpt-5.6-terra (low) | Light | Quick lookups, exploration, trivial changes |
 
 Set default model in `~/.codex/config.toml`:
 ```toml

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -105,7 +105,7 @@ Boss leitet jede Anfrage durch eine Prioritätskette, bis die beste Übereinstim
 | Komplexität | Modell | Verwendet für |
 |-------------|--------|---------------|
 | Tiefgehende Analyse, Architektur | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
-| Standardimplementierung | gpt-5.6-sol (medium) | executor, debugger, security-reviewer |
+| Standardimplementierung | gpt-5.6-sol (medium) | executor, debugger, test-engineer |
 | Schnelle Suche, Erkundung | gpt-5.6-terra (low) | explore, einfache Beratung |
 
 ### 3-Phasen-Sprint-Workflow

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -109,7 +109,7 @@ Boss cascade chaque requête dans une chaîne de priorités jusqu'à trouver la 
 | Complexité | Modèle | Utilisé pour |
 |-----------|-------|----------|
 | Analyse approfondie, architecture | gpt-6-astra (raisonnement high/xhigh) | Boss, Oracle, Sisyphus, Atlas |
-| Implémentation standard | gpt-5.6-sol (moyen) | executor, debugger, security-reviewer |
+| Implémentation standard | gpt-5.6-sol (moyen) | executor, debugger, test-engineer |
 | Recherche rapide, exploration | gpt-5.6-terra (faible) | explore, conseil simple |
 
 ### Workflow en sprint 3 phases

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -105,7 +105,7 @@ Boss はすべてのリクエストを優先チェーンにカスケードし、
 | 複雑度 | モデル | 使用場面 |
 |-----------|-------|----------|
 | 深い分析、アーキテクチャ | gpt-6-astra (high/xhigh reasoning) | Boss、Oracle、Sisyphus、Atlas |
-| 標準的な実装 | gpt-5.6-sol (medium) | executor、debugger、security-reviewer |
+| 標準的な実装 | gpt-5.6-sol (medium) | executor、debugger、test-engineer |
 | 簡単な検索、調査 | gpt-5.6-terra (low) | explore、簡易アドバイザリー |
 
 ### 3 フェーズスプリントワークフロー

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -105,7 +105,7 @@ Boss는 가장 적합한 매칭을 찾을 때까지 모든 요청을 우선순�
 | 복잡도 | 모델 | 사용 대상 |
 |-----------|-------|----------|
 | 심층 분석, 아키텍처 | gpt-6-astra (high/xhigh reasoning) | Boss, Oracle, Sisyphus, Atlas |
-| 표준 구현 | gpt-5.6-sol (medium) | executor, debugger, security-reviewer |
+| 표준 구현 | gpt-5.6-sol (medium) | executor, debugger, test-engineer |
 | 빠른 조회, 탐색 | gpt-5.6-terra (low) | explore, 간단한 자문 |
 
 ### 3단계 스프린트 워크플로

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -105,7 +105,7 @@ Boss 对每个请求按优先级链逐级匹配，直到找到最佳方案：
 | 复杂度 | 模型 | 用途 |
 |-----------|-------|----------|
 | 深度分析、架构 | gpt-6-astra （high/xhigh reasoning） | Boss、Oracle、Sisyphus、Atlas |
-| 标准实现 | gpt-5.6-sol（medium） | executor、debugger、security-reviewer |
+| 标准实现 | gpt-5.6-sol（medium） | executor、debugger、test-engineer |
 | 快速查询、探索 | gpt-5.6-terra（low） | explore、简单咨询 |
 
 ### 三阶段冲刺工作流

--- a/install.sh
+++ b/install.sh
@@ -992,6 +992,8 @@ if [ "$SKIP_OMX" = "0" ]; then
             printf 'name = "%s"\n' "$fname"
             printf 'description = "Team orchestration specialist"\n'
             printf 'model = "%s"\n' "$MODEL_TIER_HIGH"
+            # Deliberately medium (not $MODEL_TIER_HIGH_EFFORT): these frontmatter-less
+            # omx prompts are team-orchestration relays, not deep-reasoning agents.
             printf 'model_reasoning_effort = "medium"\n'
             printf 'developer_instructions = """\n'
             tr -d '\r' < "$md_file"

--- a/scripts/model-tiers.sh
+++ b/scripts/model-tiers.sh
@@ -4,9 +4,12 @@
 # Sourced (not executed) by scripts/md-to-toml.sh and install.sh so both
 # scripts stay in sync on which Codex model backs each Claude/legacy tier.
 #
-# To roll forward on the next Codex model generation, edit ONLY the three
-# MODEL_TIER_* values below. Nothing else in this repo should hardcode a
-# model ID outside of this file (see scripts/check-model-drift.sh).
+# To roll forward on the next Codex model generation: (1) edit the three
+# MODEL_TIER_* values below and LEGACY_MODEL_MAP, (2) update OLD_MODEL_PATTERN
+# in scripts/check-model-drift.sh, (3) bump the model line in the committed
+# codex-agents/**/*.toml files and the docs (README, SETUP, CONTRIBUTING,
+# docs/, i18n). Script logic never hardcodes a model ID outside this file
+# (scripts/check-model-drift.sh enforces that); agent TOMLs and docs do.
 
 # Codex model ID per tier.
 #


### PR DESCRIPTION
Follow-up to #79's independent review. No model/effort values change.

- README + i18n (ko/ja/zh/de/fr) tier table: `security-reviewer` is overridden to HIGH by `md-to-toml.sh`, so the MEDIUM example now lists `test-engineer`.
- SETUP.md LOW row: "Light" instead of "Fast" (terra is Codex's *balanced* model).
- install.sh: comment explaining the deliberate `medium` effort on frontmatter-less omx prompts.
- model-tiers.sh: roll-forward comment lists every site a generation bump touches.

Verified: `check-model-drift.sh` OK (94 files, 27 on-tier); `bash install.sh` from this tree → 12 astra / 20 sol / 2 terra.

Not changed (deliberate): pack agents keep their own `model_reasoning_effort` (15 × high, 2 × medium) — they pin effort per agent by design.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p